### PR TITLE
 set settings.userData field in CTS test for index settings

### DIFF
--- a/src/commonTest/kotlin/suite/TestSuiteSettings.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteSettings.kt
@@ -45,7 +45,9 @@ internal class TestSuiteSettings {
                     userData = json { "customUserData" to 42.0 }
                 )
                 setSettings(copy).wait() shouldEqual TaskStatus.Published
-                getSettings() shouldEqual copy
+                getSettings() shouldEqual copy.copy(
+                    userData = json { "customUserData" to 42 } // Round value expected to deserialize as int
+                )
             }
         }
     }

--- a/src/commonTest/kotlin/suite/TestSuiteSettings.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteSettings.kt
@@ -8,6 +8,7 @@ import com.algolia.search.model.search.TypoTolerance
 import com.algolia.search.model.settings.Distinct
 import com.algolia.search.model.settings.Settings
 import com.algolia.search.model.task.TaskStatus
+import kotlinx.serialization.json.json
 import runBlocking
 import shouldEqual
 import kotlin.test.AfterTest
@@ -40,7 +41,8 @@ internal class TestSuiteSettings {
                     typoTolerance = TypoTolerance.Min,
                     ignorePlurals = IgnorePlurals.QueryLanguages(Language.English, Language.French),
                     removeStopWords = RemoveStopWords.QueryLanguages(Language.English, Language.French),
-                    distinct = Distinct(1)
+                    distinct = Distinct(1),
+                    userData = json { "customUserData" to 42.0 }
                 )
                 setSettings(copy).wait() shouldEqual TaskStatus.Published
                 getSettings() shouldEqual copy


### PR DESCRIPTION
Fixes #92. @aseure can you have a look at the whole test? Unless I get [the specs](https://github.com/algolia/algoliasearch-client-specs/pull/38/files#diff-5ef12c50215bec6c93882f66c93ba8abR161) wrong, it's lacking the `saveObject` call.

Also, in the response the value gets deserialized as `Int` as it is a round number. I adapted the test, but let's confirm this is the behavior we want before merging!  