### PR TITLE
feat: upgrade Ktor & serialization

### DIFF
--- a/buildSrc/src/main/kotlin/Ktor.kt
+++ b/buildSrc/src/main/kotlin/Ktor.kt
@@ -2,5 +2,5 @@ object Ktor : Dependency {
 
     override val group = "io.ktor"
     override val artifact = "ktor"
-    override val version = "1.2.3"
+    override val version = "1.2.4"
 }

--- a/buildSrc/src/main/kotlin/Serialization.kt
+++ b/buildSrc/src/main/kotlin/Serialization.kt
@@ -1,6 +1,6 @@
 object Serialization : Dependency {
 
-    override val version = "0.11.1"
+    override val version = "0.12.0"
     override val group = "org.jetbrains.kotlinx"
     override val artifact = "kotlinx-serialization"
 }


### PR DESCRIPTION
We use Ktor & serialization on our project too. I found that `allowStructuredMapKeys` flag added in [`0.12.0`](https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md#v0120--2019-08-23) will cause upgrade failed. 