### PR TITLE
Hotfix/advanced search disjunctive filters

### DIFF
--- a/src/commonMain/kotlin/com/algolia/search/model/filter/FilterGroupsConverter.kt
+++ b/src/commonMain/kotlin/com/algolia/search/model/filter/FilterGroupsConverter.kt
@@ -14,7 +14,7 @@ public sealed class FilterGroupsConverter<I, O> : (I) -> O {
 
         override fun invoke(groups: Set<FilterGroup<*>>): String? {
             return if (groups.isNotEmpty()) {
-                groups.joinToString(separator = " AND ") { group ->
+                groups.filterNot { it.isEmpty() }.joinToString(separator = " AND ") { group ->
                     val separator = when (group) {
                         is FilterGroup.And -> " AND "
                         is FilterGroup.Or -> " OR "

--- a/src/commonMain/kotlin/com/algolia/search/model/multicluster/ClusterName.kt
+++ b/src/commonMain/kotlin/com/algolia/search/model/multicluster/ClusterName.kt
@@ -11,14 +11,10 @@ import kotlinx.serialization.internal.StringSerializer
 
 
 /**
- * [ClusterName] of a cluster. Can't be a blank or empty string.
+ * [ClusterName] of a cluster.
  */
 @Serializable(ClusterName.Companion::class)
 public data class ClusterName(override val raw: String) : Raw<String> {
-
-    init {
-        if (raw.isBlank()) throw EmptyStringException("ClusterName")
-    }
 
     override fun toString(): String {
         return raw

--- a/src/commonTest/kotlin/suite/TestSuiteDisjunctive.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteDisjunctive.kt
@@ -56,7 +56,7 @@ internal class TestSuiteDisjunctive {
             )
             val filterGroups = setOf(
                 FilterGroup.Or.Facet(filters),
-                FilterGroup.And.Facet( Filter.Facet(category, "device"))
+                FilterGroup.And.Facet(Filter.Facet(category, "device"))
             )
 
             index.apply {


### PR DESCRIPTION
When performing **advancedSearch**, the filters for the query used for returning actual results where flattened, losing the proper boolean operator (OR / AND) in the process.

Example:

```
[FilterGroup.Or(FilterA, FilterB), FilterGroup.OR(FilterC, FilterD)]
```

should translate into

```
(FilterA OR FilterB) AND (FilterC OR FilterD)
```

but is translated into

```
FilterA OR FilterB OR FilterC OR FilterD
```

This PR resolves this issue.