### PR TITLE
fix(restrictSources): Ensure secured API key param `restrictSources` only accepts string

### DIFF
--- a/src/commonMain/kotlin/com/algolia/search/model/apikey/SecuredAPIKeyRestriction.kt
+++ b/src/commonMain/kotlin/com/algolia/search/model/apikey/SecuredAPIKeyRestriction.kt
@@ -43,10 +43,17 @@ public data class SecuredAPIKeyRestriction(
                     }
                 }
             }
-            restrictIndices?.let { append("restrictIndices", it.joinToString(";") { indexName -> indexName.raw }) }
-            restrictSources?.let { append("restrictSources", it) }
-            userToken?.let { append("userToken", it.raw) }
-            validUntil?.let { append("validUntil", it.toString()) }
+            restrictIndices?.let { append(RESTRICT_INDICES, it.joinToString(";") { indexName -> indexName.raw }) }
+            restrictSources?.let { append(RESTRICT_SOURCES, it) }
+            userToken?.let { append(USER_TOKEN, it.raw) }
+            validUntil?.let { append(VALID_UNTIL, it.toString()) }
         }.formUrlEncode()
+    }
+
+    companion object {
+        private const val RESTRICT_INDICES = "restrictIndices"
+        private const val RESTRICT_SOURCES = "restrictSources"
+        private const val USER_TOKEN = "userToken"
+        private const val VALID_UNTIL = "validUntil"
     }
 }

--- a/src/commonMain/kotlin/com/algolia/search/model/apikey/SecuredAPIKeyRestriction.kt
+++ b/src/commonMain/kotlin/com/algolia/search/model/apikey/SecuredAPIKeyRestriction.kt
@@ -28,7 +28,7 @@ import kotlinx.serialization.json.content
 public data class SecuredAPIKeyRestriction(
     val query: Query? = null,
     val restrictIndices: List<IndexName>? = null,
-    val restrictSources: List<String>? = null,
+    val restrictSources: String? = null,
     val validUntil: Long? = null,
     val userToken: UserToken? = null
 ) {
@@ -44,7 +44,7 @@ public data class SecuredAPIKeyRestriction(
                 }
             }
             restrictIndices?.let { append("restrictIndices", it.joinToString(";") { indexName -> indexName.raw }) }
-            restrictSources?.let { append("restrictSources", it.joinToString(";")) }
+            restrictSources?.let { append("restrictSources", it) }
             userToken?.let { append("userToken", it.raw) }
             validUntil?.let { append("validUntil", it.toString()) }
         }.formUrlEncode()

--- a/src/commonTest/kotlin/documentation/methods/apikey/DocGenerateAPIKey.kt
+++ b/src/commonTest/kotlin/documentation/methods/apikey/DocGenerateAPIKey.kt
@@ -68,7 +68,7 @@ internal class DocGenerateAPIKey {
     fun snippet4() {
         val parentAPIKey = APIKey("SearchOnlyApiKeyKeptPrivate")
         val restriction = SecuredAPIKeyRestriction(
-            restrictSources = listOf("192.168.1.0/24")
+            restrictSources = "192.168.1.0/24"
         )
 
         ClientSearch.generateAPIKey(parentAPIKey, restriction)

--- a/src/commonTest/kotlin/model/apikey/TestSecuredAPIKeyRestriction.kt
+++ b/src/commonTest/kotlin/model/apikey/TestSecuredAPIKeyRestriction.kt
@@ -16,13 +16,13 @@ internal class TestSecuredAPIKeyRestriction {
     fun test() {
         val restriction = SecuredAPIKeyRestriction(
             restrictIndices = listOf(indexA, indexB),
-            restrictSources = listOf("valueA", "valueB"),
+            restrictSources = "valueA",
             query = Query(query = "hello"),
             validUntil = 0,
             userToken = UserToken(unknown)
         ).buildRestrictionString()
         val query = "query=hello"
-        val restrictSources = "restrictSources=valueA%3BvalueB"
+        val restrictSources = "restrictSources=valueA"
         val restrictIndices = "restrictIndices=indexA%3BindexB"
         val validUntil = "validUntil=0"
         val userToken = "userToken=unknown"


### PR DESCRIPTION
Solves https://github.com/algolia/algoliasearch-client-kotlin/issues/165