### PR TITLE
fix(client): omit all line terminators in the base64 encoder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
     mavenCentral()
     maven { url = URI("https://dl.bintray.com/kotlin/ktor") }
     maven { url = URI("https://kotlin.bintray.com/kotlinx") }
+    maven { url = URI("https://oss.sonatype.org/content/repositories/snapshots") }
 }
 
 version = Library.version

--- a/buildSrc/src/main/kotlin/Robolectric.kt
+++ b/buildSrc/src/main/kotlin/Robolectric.kt
@@ -2,5 +2,5 @@ object Robolectric : Dependency {
 
     override val group = "org.robolectric"
     override val artifact = "robolectric"
-    override val version = "4.3.1"
+    override val version = "4.4-SNAPSHOT" // TODO: Remove the `SNAPSHOT` and the gradle repository when the final version is out.
 }

--- a/src/androidMain/kotlin/com/algolia/search/helper/Hashing.kt
+++ b/src/androidMain/kotlin/com/algolia/search/helper/Hashing.kt
@@ -16,9 +16,9 @@ internal actual fun String.sha256(key: String): String {
 }
 
 internal actual fun String.encodeBase64(): String {
-    return Base64.encodeToString(toByteArray(), Base64.DEFAULT)
+    return Base64.encodeToString(toByteArray(), Base64.NO_WRAP)
 }
 
 internal actual fun String.decodeBase64(): String {
-    return String(Base64.decode(this, Base64.DEFAULT))
+    return String(Base64.decode(this, Base64.NO_WRAP))
 }

--- a/src/androidTest/kotlin/helper/TestHashingAndroid.kt
+++ b/src/androidTest/kotlin/helper/TestHashingAndroid.kt
@@ -1,0 +1,10 @@
+package helper
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class TestHashingAndroid : TestHashing()

--- a/src/commonTest/kotlin/helper/TestHashing.kt
+++ b/src/commonTest/kotlin/helper/TestHashing.kt
@@ -1,13 +1,31 @@
 package helper
 
+import com.algolia.search.helper.decodeBase64
+import com.algolia.search.helper.encodeBase64
 import com.algolia.search.helper.sha256
 import shouldEqual
 import kotlin.test.Test
 
-internal class TestHashing {
+internal abstract class TestHashing {
 
     @Test
     fun sha256() {
         "1234".sha256("test") shouldEqual "24c4f0295e1bea74f9a5cb5bc40525c8889d11c78c4255808be00defe666671f"
+    }
+
+    @Test
+    fun encoding() {
+        val url = "AZ:/19&@';#"
+        val hash = "QVo6LzE5JkAnOyM="
+
+        url.encodeBase64() shouldEqual hash
+    }
+
+    @Test
+    fun decoding() {
+        val url = "AZ:/19&@';#"
+        val hash = "QVo6LzE5JkAnOyM="
+
+        hash.decodeBase64() shouldEqual url
     }
 }

--- a/src/jvmTest/kotlin/helper/TestHashingJVM.kt
+++ b/src/jvmTest/kotlin/helper/TestHashingJVM.kt
@@ -1,0 +1,3 @@
+package helper
+
+internal class TestHashingJVM : TestHashing()


### PR DESCRIPTION
Fixes https://github.com/algolia/instantsearch-android/issues/191
