### PR TITLE
fix(CTS): override default truststore type to JKS 

### DIFF
--- a/src/androidTest/kotlin/Actual.kt
+++ b/src/androidTest/kotlin/Actual.kt
@@ -88,3 +88,7 @@ internal actual fun loadScratch(name: String): String {
         File("../../src/commonTest/resources/$name").readText()
     }
 }
+
+internal actual fun setupTrustStoreType() {
+    System.setProperty("javax.net.ssl.trustStoreType", "JKS")
+}

--- a/src/commonTest/kotlin/Expected.kt
+++ b/src/commonTest/kotlin/Expected.kt
@@ -33,3 +33,5 @@ internal expect object DateFormat {
 
     fun parse(date: String): Long
 }
+
+internal expect fun setupTrustStoreType()

--- a/src/commonTest/kotlin/suite/TestSuiteAATest.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteAATest.kt
@@ -14,6 +14,7 @@ import com.algolia.search.serialize.KeyObjectID
 import dayInMillis
 import kotlinx.serialization.json.json
 import runBlocking
+import setupTrustStoreType
 import shouldEqual
 import shouldNotEqual
 import kotlin.test.Test
@@ -34,6 +35,10 @@ internal class TestSuiteAATest {
             customSearchParameters = Query(ignorePlurals = IgnorePlurals.True)
         )
     )
+
+    init {
+        setupTrustStoreType()
+    }
 
     @Test
     fun test() {

--- a/src/commonTest/kotlin/suite/TestSuiteRecommendation.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteRecommendation.kt
@@ -5,8 +5,6 @@ import com.algolia.search.model.recommendation.EventScoring
 import com.algolia.search.model.recommendation.FacetScoring
 import com.algolia.search.model.recommendation.PersonalizationStrategy
 import com.algolia.search.model.recommendation.SetPersonalizationStrategyResponse
-import io.ktor.client.features.ClientRequestException
-import io.ktor.http.HttpStatusCode
 import runBlocking
 import shouldEqual
 import kotlin.test.Test
@@ -37,14 +35,12 @@ internal class TestSuiteRecommendation {
 
             val response = SetPersonalizationStrategyResponse(200, "Strategy was successfully updated")
 
-            try {
-                clientRecommendation.setPersonalizationStrategy(strategy) shouldEqual response
-            } catch (e: ClientRequestException) {
-                // The personalization API is now limiting the number of setPersonalizationStrategy()` successful calls
-                // to 15 per day. If the 429 error is returned, the response is considered a "success".
-                if (e.response.status != HttpStatusCode.TooManyRequests) throw e
+            clientRecommendation.setPersonalizationStrategy(strategy).let {
+                it.shouldEqual(response)
             }
-            clientRecommendation.getPersonalizationStrategy() shouldEqual strategy
+            clientRecommendation.getPersonalizationStrategy().let {
+                it.shouldEqual(strategy)
+            }
         }
     }
 }

--- a/src/jvmTest/kotlin/Actual.kt
+++ b/src/jvmTest/kotlin/Actual.kt
@@ -90,3 +90,7 @@ internal actual fun loadScratch(name: String): String {
         File("../../src/commonTest/resources/$name").readText()
     }
 }
+
+internal actual fun setupTrustStoreType() {
+    System.setProperty("javax.net.ssl.trustStoreType", "JKS")
+}


### PR DESCRIPTION
`TestSuiteAATest` fails sometimes due to the following exception at `saveObject` step:

`java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)`

This means there is no Trust Store set for the JVM.