### PR TITLE
test(api-keys): retry on restoreApiKeys upon '[404] Key already exists' error

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ platform :android do
 
   desc "Runs all the tests"
   lane :test do
-    gradle(task: "jvmTest")
+    gradle(task: "jvmTest", flags: "-i")
   end
 
   desc "Deploy artifacts to Bintray"

--- a/src/commonTest/kotlin/Retry.kt
+++ b/src/commonTest/kotlin/Retry.kt
@@ -4,11 +4,25 @@ import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
+/**
+ * Create a [RetryableClientRequest] instance.
+ */
 @OptIn(ExperimentalTime::class)
-internal class RetryableClientRequest internal constructor(
+internal fun retryApiCall(
+    delay: Duration = 1.seconds,
+    retries: Int = 10,
+    block: suspend () -> Unit,
+): RetryableClientRequest {
+    require(delay > Duration.ZERO) { "Expected positive delay, but had $delay" }
+    require(retries > 0) { "Expected positive amount of retries, but had $retries" }
+    return RetryableClientRequest(delay, retries, block)
+}
+
+@OptIn(ExperimentalTime::class)
+internal class RetryableClientRequest(
     private val delayDuration: Duration = 1.seconds,
     private val retries: Int = 10,
-    private val block: suspend () -> Unit
+    private val block: suspend () -> Unit,
 ) {
 
     /**
@@ -25,14 +39,4 @@ internal class RetryableClientRequest internal constructor(
         }
         throw RuntimeException("reached the maximum number of retries")
     }
-}
-
-/**
- * Create a [RetryableClientRequest] instance.
- */
-@OptIn(ExperimentalTime::class)
-internal fun retryApiCall(delay: Duration = 1.seconds, retries: Int = 10, block: suspend () -> Unit): RetryableClientRequest {
-    require(delay > Duration.ZERO) { "Expected positive delay, but had $delay" }
-    require(retries > 0) { "Expected positive amount of retries, but had $retries" }
-    return RetryableClientRequest(delay, retries, block)
 }

--- a/src/commonTest/kotlin/Retry.kt
+++ b/src/commonTest/kotlin/Retry.kt
@@ -1,0 +1,38 @@
+import io.ktor.client.features.ClientRequestException
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
+
+@OptIn(ExperimentalTime::class)
+internal class RetryableClientRequest internal constructor(
+    private val delayDuration: Duration = 1.seconds,
+    private val retries: Int = 10,
+    private val block: suspend () -> Unit
+) {
+
+    /**
+     * Retries [block] calls if [retry] returns true until [retries] count is reached, otherwise throws an exception.
+     */
+    suspend fun whenever(retry: suspend (ClientRequestException) -> Boolean) {
+        for (i in 0 until retries) {
+            try {
+                block()
+            } catch (e: ClientRequestException) {
+                if (!retry(e)) throw e
+                delay(delayDuration.inMilliseconds.toLong())
+            }
+        }
+        throw RuntimeException("reached the maximum number of retries")
+    }
+}
+
+/**
+ * Create a [RetryableClientRequest] instance.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun retryApiCall(delay: Duration = 1.seconds, retries: Int = 10, block: suspend () -> Unit): RetryableClientRequest {
+    require(delay > Duration.ZERO) { "Expected positive delay, but had $delay" }
+    require(retries > 0) { "Expected positive amount of retries, but had $retries" }
+    return RetryableClientRequest(delay, retries, block)
+}

--- a/src/commonTest/kotlin/exception/AlgoliaApiException.kt
+++ b/src/commonTest/kotlin/exception/AlgoliaApiException.kt
@@ -1,0 +1,12 @@
+package exception
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Exception thrown in case of API failure such as 4XX, 5XX error.
+ **/
+@Serializable
+internal class AlgoliaApiException(
+    val status: Int?,
+    override val message: String?
+) : RuntimeException(message)


### PR DESCRIPTION
Fixes #203 
