### PR TITLE
chore(shrinker): publish ProGuard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Support and target Android API 30
 - Multi-condition rules (#201)
 _ `IncrementFrom` and `IncrementSet` built-in operations (#202)
+- Include ProGuard rules into `aar` and `jar` artifacts
 
 ### Changed
 - `indexName` required in `InnerQuery`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ extensions.getByType(LibraryExtension::class.java).apply {
         minSdkVersion(17)
         targetSdkVersion(30)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("src/jvmMain/resources/META-INF/proguard/algoliasearch.pro")
     }
 
     testOptions.unitTests.isIncludeAndroidResources = true

--- a/src/jvmMain/resources/META-INF/proguard/algoliasearch.pro
+++ b/src/jvmMain/resources/META-INF/proguard/algoliasearch.pro
@@ -1,0 +1,2 @@
+# Serializable models
+-keep class com.algolia.search.model.** { *; }


### PR DESCRIPTION
Include ProGuard rules into the artifacts and allow R8 to automatically apply them:  

* AAR: `<library-dir>/proguard.txt`
* JAR: `<library-dir>/META-INF/proguard/algoliasearch.pro`

More details: 
* https://developer.android.com/studio/build/shrink-code
* https://developer.android.com/studio/projects/android-library
