### PR TITLE
fix: use ktor implementation of base64 encoding

### DIFF
--- a/src/commonMain/kotlin/com/algolia/search/client/ClientSearch.kt
+++ b/src/commonMain/kotlin/com/algolia/search/client/ClientSearch.kt
@@ -11,8 +11,6 @@ import com.algolia.search.configuration.internal.DEFAULT_LOG_LEVEL
 import com.algolia.search.endpoint.EndpointAPIKey
 import com.algolia.search.endpoint.EndpointMultiCluster
 import com.algolia.search.endpoint.EndpointMultipleIndex
-import com.algolia.search.helper.internal.decodeBase64
-import com.algolia.search.helper.internal.encodeBase64
 import com.algolia.search.helper.internal.sha256
 import com.algolia.search.helper.toAPIKey
 import com.algolia.search.model.APIKey
@@ -30,6 +28,8 @@ import com.algolia.search.model.task.TaskIndex
 import com.algolia.search.model.task.TaskStatus
 import com.algolia.search.transport.RequestOptions
 import com.algolia.search.transport.internal.Transport
+import com.algolia.search.util.internal.decodeBase64String
+import com.algolia.search.util.internal.encodeBase64
 import io.ktor.client.features.logging.LogLevel
 
 /**
@@ -109,7 +109,7 @@ public interface ClientSearch :
          * @throws IllegalArgumentException if [apiKey] doesn't have a [SecuredAPIKeyRestriction.validUntil].
          */
         public fun getSecuredApiKeyRemainingValidity(apiKey: APIKey): Long {
-            val decoded = apiKey.raw.decodeBase64()
+            val decoded = apiKey.raw.decodeBase64String()
             val pattern = Regex("validUntil=(\\d+)")
             val match = pattern.find(decoded)
             return if (match != null) {

--- a/src/commonMain/kotlin/com/algolia/search/helper/internal/Hashing.kt
+++ b/src/commonMain/kotlin/com/algolia/search/helper/internal/Hashing.kt
@@ -2,6 +2,3 @@ package com.algolia.search.helper.internal
 
 internal expect fun String.sha256(key: String): String
 
-internal expect fun String.encodeBase64(): String
-
-internal expect fun String.decodeBase64(): String

--- a/src/commonMain/kotlin/com/algolia/search/util/internal/Base64.kt
+++ b/src/commonMain/kotlin/com/algolia/search/util/internal/Base64.kt
@@ -1,0 +1,98 @@
+package com.algolia.search.util.internal
+
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.ByteReadPacket
+import io.ktor.utils.io.core.Input
+import io.ktor.utils.io.core.String
+import io.ktor.utils.io.core.buildPacket
+import io.ktor.utils.io.core.readAvailable
+import io.ktor.utils.io.core.readBytes
+import io.ktor.utils.io.core.writeFully
+import io.ktor.utils.io.core.writeText
+import kotlin.experimental.and
+
+private const val BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+private const val BASE64_MASK: Byte = 0x3f
+private const val BASE64_PAD = '='
+
+private val BASE64_INVERSE_ALPHABET = IntArray(256) {
+    BASE64_ALPHABET.indexOf(it.toChar())
+}
+
+/**
+ * Encode [String] in base64 format and UTF-8 character encoding.
+ */
+internal fun String.encodeBase64(): String = buildPacket {
+    writeText(this@encodeBase64)
+}.encodeBase64()
+
+/**
+ * Encode [ByteArray] in base64 format
+ */
+internal fun ByteArray.encodeBase64(): String = buildPacket {
+    writeFully(this@encodeBase64)
+}.encodeBase64()
+
+/**
+ * Encode [ByteReadPacket] in base64 format
+ */
+internal fun ByteReadPacket.encodeBase64(): String = buildString {
+    val data = ByteArray(3)
+    while (remaining > 0) {
+        val read = readAvailable(data)
+        data.clearFrom(read)
+
+        val padSize = (data.size - read) * 8 / 6
+        val chunk = ((data[0].toInt() and 0xFF) shl 16) or
+            ((data[1].toInt() and 0xFF) shl 8) or
+            (data[2].toInt() and 0xFF)
+
+        for (index in data.size downTo padSize) {
+            val char = (chunk shr (6 * index)) and BASE64_MASK.toInt()
+            append(char.toBase64())
+        }
+
+        repeat(padSize) { append(BASE64_PAD) }
+    }
+}
+
+/**
+ * Decode [String] from base64 format encoded in UTF-8.
+ */
+internal fun String.decodeBase64String(): String = String(decodeBase64Bytes(), charset = Charsets.UTF_8)
+
+/**
+ * Decode [String] from base64 format
+ */
+internal fun String.decodeBase64Bytes(): ByteArray = buildPacket {
+    writeText(dropLastWhile { it == BASE64_PAD })
+}.decodeBase64Bytes().readBytes()
+
+/**
+ * Decode [ByteReadPacket] from base64 format
+ */
+
+internal fun ByteReadPacket.decodeBase64Bytes(): Input = buildPacket {
+    val data = ByteArray(4)
+
+    while (remaining > 0) {
+        val read = readAvailable(data)
+
+        val chunk = data.foldIndexed(0) { index, result, current ->
+            result or (current.fromBase64().toInt() shl ((3 - index) * 6))
+        }
+
+        for (index in data.size - 2 downTo (data.size - read)) {
+            val origin = (chunk shr (8 * index)) and 0xff
+            writeByte(origin.toByte())
+        }
+    }
+}
+
+internal fun ByteArray.clearFrom(from: Int) {
+    (from until size).forEach { this[it] = 0 }
+}
+
+internal fun Int.toBase64(): Char = BASE64_ALPHABET[this]
+
+internal fun Byte.fromBase64(): Byte = BASE64_INVERSE_ALPHABET[toInt() and 0xff].toByte() and BASE64_MASK

--- a/src/commonTest/kotlin/util/TestHashing.kt
+++ b/src/commonTest/kotlin/util/TestHashing.kt
@@ -1,12 +1,12 @@
-package helper
+package util
 
-import com.algolia.search.helper.internal.decodeBase64
-import com.algolia.search.helper.internal.encodeBase64
 import com.algolia.search.helper.internal.sha256
+import com.algolia.search.util.internal.decodeBase64String
+import com.algolia.search.util.internal.encodeBase64
 import shouldEqual
 import kotlin.test.Test
 
-internal abstract class TestHashing {
+internal class TestHashing {
 
     @Test
     fun sha256() {
@@ -17,7 +17,6 @@ internal abstract class TestHashing {
     fun encoding() {
         val url = "AZ:/19&@';#"
         val hash = "QVo6LzE5JkAnOyM="
-
         url.encodeBase64() shouldEqual hash
     }
 
@@ -26,6 +25,6 @@ internal abstract class TestHashing {
         val url = "AZ:/19&@';#"
         val hash = "QVo6LzE5JkAnOyM="
 
-        hash.decodeBase64() shouldEqual url
+        hash.decodeBase64String() shouldEqual url
     }
 }

--- a/src/jvmMain/kotlin/com/algolia/search/helper/internal/Hashing.kt
+++ b/src/jvmMain/kotlin/com/algolia/search/helper/internal/Hashing.kt
@@ -1,7 +1,6 @@
 package com.algolia.search.helper.internal
 
 import io.ktor.utils.io.core.toByteArray
-import java.util.Base64
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -15,10 +14,3 @@ internal actual fun String.sha256(key: String): String {
     }
 }
 
-internal actual fun String.encodeBase64(): String {
-    return String(Base64.getEncoder().encode(toByteArray()))
-}
-
-internal actual fun String.decodeBase64(): String {
-    return String(Base64.getDecoder().decode(this))
-}

--- a/src/jvmTest/kotlin/helper/TestHashingJVM.kt
+++ b/src/jvmTest/kotlin/helper/TestHashingJVM.kt
@@ -1,3 +1,0 @@
-package helper
-
-internal class TestHashingJVM : TestHashing()


### PR DESCRIPTION
As mentioned in #216:
Java Base64 implementation (`java.util.Base64`) is available only since Android [API 26](https://developer.android.com/reference/java/util/Base64).
In this PR, we use Ktor's implementation instead.

Fixes #216 