### PR TITLE
test(apiKeys): make the TestSuiteAPIKey test runnable

### DIFF
--- a/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.isActive
 import runBlocking
 import shouldBeTrue
 import shouldEqual
-import kotlin.test.AfterTest
+import kotlin.test.Test
 
 internal class TestSuiteAPIKey {
 
@@ -33,7 +33,7 @@ internal class TestSuiteAPIKey {
         validity = 600
     )
 
-    @AfterTest
+    @Test
     fun test() {
         runBlocking {
             clientAdmin1.apply {


### PR DESCRIPTION
Change testing annotation to make `TestSuiteAPIKey` CTS test run.
The looping behavior is already [coded](https://github.com/algolia/algoliasearch-client-kotlin/blob/9ca03914bf6f1a14bbb64823498b61a909fb5c9d/src/commonMain/kotlin/com/algolia/search/client/internal/ClientSearchImpl.kt#L92-L105).

Fixes #203

