### PR TITLE
chore: update Ktor to 1.4.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Changed
+- Update Ktor to 1.4.0 transitively Kotlin serialization to `1.0.0-RC2`
+
 # 1.5.0
 
 ### Added

--- a/buildSrc/src/main/kotlin/Ktor.kt
+++ b/buildSrc/src/main/kotlin/Ktor.kt
@@ -2,5 +2,5 @@ object Ktor : Dependency {
 
     override val group = "io.ktor"
     override val artifact = "ktor"
-    override val version = "1.4.0"
+    override val version = "1.4.1"
 }

--- a/src/commonMain/kotlin/com/algolia/search/client/ClientAccount.kt
+++ b/src/commonMain/kotlin/com/algolia/search/client/ClientAccount.kt
@@ -28,7 +28,7 @@ public object ClientAccount {
         try {
             destination.getSettings()
         } catch (exception: ResponseException) {
-            hasThrown404 = exception.response?.status?.value == HttpStatusCode.NotFound.value
+            hasThrown404 = exception.response.status.value == HttpStatusCode.NotFound.value
             if (!hasThrown404) throw exception
         }
         if (!hasThrown404) {

--- a/src/commonMain/kotlin/com/algolia/search/client/internal/ClientSearchImpl.kt
+++ b/src/commonMain/kotlin/com/algolia/search/client/internal/ClientSearchImpl.kt
@@ -96,7 +96,7 @@ internal class ClientSearchImpl internal constructor(
                 try {
                     return getAPIKey(apiKey)
                 } catch (exception: ResponseException) {
-                    if (exception.response?.status?.value != HttpStatusCode.NotFound.value) throw exception
+                    if (exception.response.status.value != HttpStatusCode.NotFound.value) throw exception
                 }
                 delay(1000L)
             }
@@ -118,7 +118,7 @@ internal class ClientSearchImpl internal constructor(
                 try {
                     getAPIKey(apiKey)
                 } catch (exception: ResponseException) {
-                    if (exception.response?.status?.value == HttpStatusCode.NotFound.value) return true else throw exception
+                    if (exception.response.status.value == HttpStatusCode.NotFound.value) return true else throw exception
                 }
                 delay(1000L)
             }

--- a/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointIndex.kt
+++ b/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointIndex.kt
@@ -68,7 +68,7 @@ internal class EndpointIndexImpl(
         try {
             EndpointSearch(transport, indexName).search(Query(responseFields = emptyList()))
         } catch (exception: ResponseException) {
-            if (exception.response?.status == HttpStatusCode.NotFound) return false
+            if (exception.response.status == HttpStatusCode.NotFound) return false
         }
         return true
     }

--- a/src/commonMain/kotlin/com/algolia/search/helper/ResponseException.kt
+++ b/src/commonMain/kotlin/com/algolia/search/helper/ResponseException.kt
@@ -8,5 +8,5 @@ import io.ktor.utils.io.core.String
  * Convenience method to convert [ResponseException.response] body bytes to a [String].
  */
 public suspend fun ResponseException.readContent(): String? {
-    return response?.readBytes()?.let { String(it) }
+    return String(response.readBytes())
 }

--- a/src/commonMain/kotlin/com/algolia/search/serialize/internal/Json.kt
+++ b/src/commonMain/kotlin/com/algolia/search/serialize/internal/Json.kt
@@ -21,12 +21,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 
-internal val Json = Json.Default
-internal val JsonNoDefaults = Json { encodeDefaults = false }
+internal val Json = Json { encodeDefaults = true }
+internal val JsonNoDefaults = Json.Default
 internal val JsonNonStrict = Json {
     ignoreUnknownKeys = true
     isLenient = true
     allowSpecialFloatingPointValues = true
+    encodeDefaults = true
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
+++ b/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
@@ -92,7 +92,7 @@ internal class Transport(
             } catch (exception: IOException) {
                 mutex.withLock { host.hasFailed() }
             } catch (exception: ResponseException) {
-                val value = exception.response?.status?.value ?: 0
+                val value = exception.response.status.value
                 val isRetryable = floor(value / 100f) != 4f
 
                 if (isRetryable) mutex.withLock { host.hasFailed() } else throw exception

--- a/src/commonTest/kotlin/configuration/TestUserAgent.kt
+++ b/src/commonTest/kotlin/configuration/TestUserAgent.kt
@@ -73,9 +73,9 @@ internal class TestUserAgent {
             val request = shouldFailWith<ResponseException> {
                 client.listIndices(requestOptions)
             }
-            val headers = request.response?.call?.request?.headers
+            val headers = request.response.call.request.headers
 
-            headers?.get(userAgentKey) shouldEqual expected
+            headers.get(userAgentKey) shouldEqual expected
         }
     }
 }

--- a/src/commonTest/kotlin/documentation/reference/DocPhilosophy.kt
+++ b/src/commonTest/kotlin/documentation/reference/DocPhilosophy.kt
@@ -179,7 +179,7 @@ internal class DocPhilosophy {
             try {
                 val response = index.search()
             } catch (exception: ResponseException) {
-                when (exception.response?.status) {
+                when (exception.response.status) {
                     HttpStatusCode.NotFound -> TODO()
                     HttpStatusCode.BadRequest -> TODO()
                 }

--- a/src/commonTest/kotlin/suite/TestSuiteABTest.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteABTest.kt
@@ -62,7 +62,7 @@ internal class TestSuiteABTest {
                     clientAnalytics.getABTest(responseA.abTestID)
                 }
 
-                responseB.response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                responseB.response.status.value shouldEqual HttpStatusCode.NotFound.value
             }
         }
     }

--- a/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
@@ -62,7 +62,7 @@ internal class TestSuiteAPIKey {
                     try {
                         if (getAPIKey(key).maxHitsPerQuery == 42) break
                     } catch (exception: ResponseException) {
-                        exception.response?.status?.value shouldEqual HttpStatusCode.NotFound
+                        exception.response.status.value shouldEqual HttpStatusCode.NotFound
                     }
                     delay(1000L)
                 }

--- a/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
@@ -35,7 +35,7 @@ internal class TestSuiteMultiCluster {
                 clientMcm.getUserID(userID)
                 break
             } catch (exception: ResponseException) {
-                exception.response?.status shouldEqual HttpStatusCode.NotFound
+                exception.response.status shouldEqual HttpStatusCode.NotFound
             }
             delay(1000L)
         }
@@ -47,7 +47,7 @@ internal class TestSuiteMultiCluster {
                 clientMcm.removeUserID(userID)
             } catch (exception: ResponseException) {
                 val response = exception.response
-                when (response?.status) {
+                when (response.status) {
                     HttpStatusCode.NotFound -> break@loop
                     HttpStatusCode.BadRequest ->
                         if (String(response.readBytes()).contains("is already migrating")) {

--- a/src/commonTest/kotlin/suite/TestSuiteRecommendation.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteRecommendation.kt
@@ -42,7 +42,7 @@ internal class TestSuiteRecommendation {
             } catch (e: ClientRequestException) {
                 // The personalization API is now limiting the number of setPersonalizationStrategy()` successful calls
                 // to 15 per day. If the 429 error is returned, the response is considered a "success".
-                if (e.response?.status != HttpStatusCode.TooManyRequests) throw e
+                if (e.response.status != HttpStatusCode.TooManyRequests) throw e
             }
             clientRecommendation.getPersonalizationStrategy() shouldEqual strategy
         }

--- a/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
@@ -57,19 +57,19 @@ class TestSuiteReplaceAll {
                     shouldFailWith<ResponseException> {
                         getObject(objectIDOne)
                     }
-                    ).response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
 
                 (
                     shouldFailWith<ResponseException> {
                         getSynonym(objectIDOne)
                     }
-                    ).response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
 
                 (
                     shouldFailWith<ResponseException> {
                         getRule(objectIDOne)
                     }
-                    ).response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
             }
         }
     }

--- a/src/commonTest/kotlin/suite/TestSuiteRules.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteRules.kt
@@ -62,7 +62,7 @@ internal class TestSuiteRules {
                     shouldFailWith<ResponseException> {
                         getRule(rule.objectID)
                     }
-                    ).response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
                 clearRules().wait() shouldEqual TaskStatus.Published
                 searchRules().nbHits shouldEqual 0
             }

--- a/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
+++ b/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
@@ -70,7 +70,7 @@ internal class TestSuiteSynonyms {
                     shouldFailWith<ResponseException> {
                         getSynonym(gba)
                     }
-                    ).response?.status?.value shouldEqual HttpStatusCode.NotFound.value
+                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
 
                 clearSynonyms().wait() shouldEqual TaskStatus.Published
                 searchSynonyms(SynonymQuery(page = 0, hitsPerPage = 10)).nbHits shouldEqual 0


### PR DESCRIPTION
Update Ktor to [1.4.1](https://github.com/ktorio/ktor/releases/tag/1.4.1) and transitively Kotlin serialization to [1.0.0-RC2](https://github.com/Kotlin/kotlinx.serialization).

_Noticeable change:_
> `encodeDefaults` flag is now set to `false` in the default configuration for JSON, CBOR and Protocol Buffers.