### PR TITLE
fix(analytics): correct AB testing average click pos type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Fixed
+- AB testing average click pos type from `Int` to `Float`
+
 ### Changed
 - Update Ktor to 1.4.0 transitively Kotlin serialization to `1.0.0-RC2`
 

--- a/src/commonMain/kotlin/com/algolia/search/model/response/ResponseVariant.kt
+++ b/src/commonMain/kotlin/com/algolia/search/model/response/ResponseVariant.kt
@@ -42,7 +42,7 @@ public data class ResponseVariant(
     /**
      * Average click position for the variant.
      */
-    @SerialName(KeyAverageClickPosition) val averageClickPositionOrNull: Int? = null,
+    @SerialName(KeyAverageClickPosition) val averageClickPositionOrNull: Float? = null,
     @SerialName(KeySearchCount) val searchCountOrNull: Long? = null,
     @SerialName(KeyTrackedSearchCount) val trackedSearchCountOrNull: Long? = null,
     @SerialName(KeyUserCount) val userCountOrNull: Long? = null,
@@ -59,7 +59,7 @@ public data class ResponseVariant(
     public val noResultCount: Int
         get() = noResultCountOrNull!!
 
-    public val averageClickPosition: Int
+    public val averageClickPosition: Float
         get() = averageClickPositionOrNull!!
 
     public val searchCount: Long

--- a/src/commonTest/kotlin/documentation/guides/optimize/intent/GuideDynamicFiltering.kt
+++ b/src/commonTest/kotlin/documentation/guides/optimize/intent/GuideDynamicFiltering.kt
@@ -6,8 +6,6 @@ import com.algolia.search.dsl.optionalFilters
 import com.algolia.search.dsl.query
 import com.algolia.search.dsl.rule.rules
 import com.algolia.search.dsl.settings
-import com.algolia.search.model.rule.Condition
-import com.algolia.search.model.rule.Consequence
 import documentation.index
 import runBlocking
 import kotlin.test.Ignore
@@ -36,9 +34,9 @@ internal class GuideDynamicFiltering {
                 rule(
                     "gluten-free-rule",
                     conditions {
-                        +Condition(Contains, Literal("gluten-free"))
+                        +condition(Contains, Literal("gluten-free"))
                     },
-                    Consequence(
+                    consequence(
                         edits = edits { +"gluten-free" },
                         query = query {
                             filters { and { facet("allergens", "gluten", isNegated = true) } }
@@ -58,9 +56,9 @@ internal class GuideDynamicFiltering {
                 rule(
                     "diet-rule",
                     conditions {
-                        +Condition(Contains, Literal("diet"))
+                        +condition(Contains, Literal("diet"))
                     },
-                    Consequence(
+                    consequence(
                         edits = edits { +"diet" },
                         query = query {
                             filters {
@@ -98,15 +96,39 @@ internal class GuideDynamicFiltering {
                 rule(
                     "asap-rule",
                     conditions {
-                        +Condition(Contains, Literal("asap"))
+                        +condition(Contains, Literal("asap"))
                     },
-                    Consequence(
+                    consequence(
                         edits = edits { +"asap" },
                         query = query {
                             optionalFilters {
                                 and {
                                     facet("can_deliver_quickly", "true")
                                 }
+                            }
+                        }
+                    )
+                )
+            }
+
+            index.saveRules(rules)
+        }
+    }
+
+    @Test
+    fun snippet6() {
+        runBlocking {
+            val rules = rules {
+                rule(
+                    "cheap",
+                    conditions {
+                        +condition(Contains, Literal("cheap"))
+                    },
+                    consequence(
+                        edits = edits { +"cheap" },
+                        query = query {
+                            filters {
+                                and { comparison("price", Less, 10) }
                             }
                         }
                     )

--- a/src/commonTest/kotlin/serialize/response/TestResponseVariant.kt
+++ b/src/commonTest/kotlin/serialize/response/TestResponseVariant.kt
@@ -38,7 +38,7 @@ internal class TestResponseVariant : TestSerializer<ResponseVariant>(ResponseVar
             trafficPercentage = 2,
             conversionRateOrNull = 3f,
             noResultCountOrNull = 4,
-            averageClickPositionOrNull = 5,
+            averageClickPositionOrNull = 5f,
             searchCountOrNull = 6,
             trackedSearchCountOrNull = 7,
             userCountOrNull = 8,
@@ -54,7 +54,7 @@ internal class TestResponseVariant : TestSerializer<ResponseVariant>(ResponseVar
             put(KeyTrafficPercentage, 2)
             put(KeyConversionRate, 3f)
             put(KeyNoResultCount, 4)
-            put(KeyAverageClickPosition, 5)
+            put(KeyAverageClickPosition, 5f)
             put(KeySearchCount, 6)
             put(KeyTrackedSearchCount, 7)
             put(KeyUserCount, 8)


### PR DESCRIPTION
The type of `averageClickPosition` field in variant response structure must be `Float`.