### PR TITLE
fix: set 'order' default value to empty list

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetValuesOrder.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetValuesOrder.kt
@@ -10,7 +10,7 @@ public data class FacetValuesOrder(
     /**
      * Pinned order of facet values.
      */
-    @SerialName(KeyOrder) public val order: List<String>,
+    @SerialName(KeyOrder) public val order: List<String> = emptyList(),
     /**
      * How to display the remaining items.
      */


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Set `FacetValuesOrder`'s field `order` to default value `emptyList()`