### PR TITLE
fix: include _operation for partialUpdateObjects

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/indexing/BatchOperation.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/indexing/BatchOperation.kt
@@ -100,10 +100,11 @@ public sealed class BatchOperation(override val raw: String) : Raw<String> {
             ): PartialUpdateObject {
                 return PartialUpdateObject(
                     objectID,
-                    buildJsonObject {
-                        put(partial.attribute.raw, partial.value)
-                        put(KeyObjectID, objectID.raw)
-                    },
+                    Json.encodeToJsonElement(Partial, partial).jsonObject.merge(
+                        buildJsonObject {
+                            put(KeyObjectID, objectID.raw)
+                        }
+                    ),
                     createIfNotExists
                 )
             }

--- a/client/src/commonTest/kotlin/serialize/indexing/TestPartialUpdate.kt
+++ b/client/src/commonTest/kotlin/serialize/indexing/TestPartialUpdate.kt
@@ -66,9 +66,13 @@ internal class TestPartialUpdate : TestSerializer<Partial>(Partial) {
         return buildJsonObject {
             put(
                 partial.attribute.raw,
-                buildJsonObject {
-                    key?.let { put(Key_Operation, key) }
-                    put(KeyValue, partial.value)
+                key?.let {
+                    buildJsonObject {
+                        put(Key_Operation, key)
+                        put(KeyValue, partial.value)
+                    }
+                } ?: run {
+                    partial.value
                 }
             )
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #294
| Need Doc update   | no


## Describe your change

- change ```PartialUpdateObject.from``` to include ```_operation``` for ```Index.partialUpdateObjects```
	- because ```Index.partialUpdateObjects``` uses this
- change ```serialize/deserialize``` method of ```Partial``` class
	- json structure depends on ```Key_Operation```

## What problem is this fixing?

resolves #294
