### PR TITLE
fix: sharing `SimpleDateFormat` instances

### DIFF
--- a/client/src/jvmMain/kotlin/com/algolia/search/helper/internal/Date.kt
+++ b/client/src/jvmMain/kotlin/com/algolia/search/helper/internal/Date.kt
@@ -6,11 +6,11 @@ import java.util.TimeZone
 
 internal actual object DateISO8601 {
 
-    val dateISO8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").apply {
+    val dateISO8601 get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 
-    val dateISO8601Millis = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").apply {
+    val dateISO8601Millis get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #293 
| Need Doc update   | no


## Describe your change

Move from using a single instance of [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) for parsing operations.

---
_Notes:_
* Avoiding Java 8 thread-safe alternatives, since not available in Android until API 26
* Kotlin Serialization use of coroutines prevents us from considering  `ThreadLocal`
* Keeping away from introducing an external new dependency to a DateTime library