### PR TITLE
chore: add `binary-compatibility-validator`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ buildscript {
         classpath(kotlin("serialization", version = kotlinVersion))
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
         classpath("com.diffplug.spotless:spotless-plugin-gradle:5.15.0")
+        classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.7.1")
     }
 }
 

--- a/client/api/client.api
+++ b/client/api/client.api
@@ -1,0 +1,12500 @@
+public abstract interface annotation class com/algolia/search/ExperimentalAlgoliaClientAPI : java/lang/annotation/Annotation {
+}
+
+public final class com/algolia/search/client/ClientAccount {
+	public static final field INSTANCE Lcom/algolia/search/client/ClientAccount;
+	public final fun copyIndex (Lcom/algolia/search/client/Index;Lcom/algolia/search/client/Index;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/client/ClientAnalytics : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials, com/algolia/search/endpoint/EndpointAnalytics {
+	public static final field Companion Lcom/algolia/search/client/ClientAnalytics$Companion;
+	public abstract fun browseAllABTests (Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/client/ClientAnalytics$Companion {
+}
+
+public final class com/algolia/search/client/ClientAnalytics$DefaultImpls {
+	public static synthetic fun browseAllABTests$default (Lcom/algolia/search/client/ClientAnalytics;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getTimeout (Lcom/algolia/search/client/ClientAnalytics;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/client/ClientAnalyticsKt {
+	public static final fun ClientAnalytics (Lcom/algolia/search/configuration/ConfigurationAnalytics;)Lcom/algolia/search/client/ClientAnalytics;
+	public static final fun ClientAnalytics (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Analytics;)Lcom/algolia/search/client/ClientAnalytics;
+}
+
+public abstract interface class com/algolia/search/client/ClientInsights : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials, com/algolia/search/endpoint/EndpointInsights {
+	public static final field Companion Lcom/algolia/search/client/ClientInsights$Companion;
+	public abstract fun User (Lcom/algolia/search/model/insights/UserToken;)Lcom/algolia/search/client/ClientInsights$User;
+}
+
+public final class com/algolia/search/client/ClientInsights$Companion {
+}
+
+public final class com/algolia/search/client/ClientInsights$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/client/ClientInsights;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/client/ClientInsights$User : com/algolia/search/endpoint/EndpointInsightsUser {
+	public fun <init> (Lcom/algolia/search/endpoint/EndpointInsights;Lcom/algolia/search/model/insights/UserToken;)V
+	public fun clickedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clickedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clickedObjectIDsAfterSearch (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun convertedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun convertedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun convertedObjectIDsAfterSearch (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getInsights ()Lcom/algolia/search/endpoint/EndpointInsights;
+	public final fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun viewedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun viewedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/client/ClientInsightsKt {
+	public static final fun ClientInsights (Lcom/algolia/search/configuration/ConfigurationInsights;)Lcom/algolia/search/client/ClientInsights;
+	public static final fun ClientInsights (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;)Lcom/algolia/search/client/ClientInsights;
+}
+
+public abstract interface class com/algolia/search/client/ClientPersonalization : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials, com/algolia/search/endpoint/EndpointPersonalization {
+	public static final field Companion Lcom/algolia/search/client/ClientPersonalization$Companion;
+}
+
+public final class com/algolia/search/client/ClientPersonalization$Companion {
+}
+
+public final class com/algolia/search/client/ClientPersonalization$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/client/ClientPersonalization;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/client/ClientPersonalizationKt {
+	public static final fun ClientPersonalization (Lcom/algolia/search/configuration/ConfigurationPersonalization;)Lcom/algolia/search/client/ClientPersonalization;
+	public static final fun ClientPersonalization (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Personalization;)Lcom/algolia/search/client/ClientPersonalization;
+	public static final fun ClientRecommendation (Lcom/algolia/search/configuration/ConfigurationPersonalization;)Lcom/algolia/search/client/ClientPersonalization;
+	public static final fun ClientRecommendation (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Recommendation;)Lcom/algolia/search/client/ClientPersonalization;
+}
+
+public abstract interface class com/algolia/search/client/ClientPlaces : com/algolia/search/configuration/Configuration, com/algolia/search/endpoint/EndpointPlaces {
+	public static final field Companion Lcom/algolia/search/client/ClientPlaces$Companion;
+}
+
+public final class com/algolia/search/client/ClientPlaces$Companion {
+}
+
+public final class com/algolia/search/client/ClientPlaces$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/client/ClientPlaces;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/client/ClientPlacesKt {
+	public static final fun ClientPlaces (Lcom/algolia/search/configuration/ConfigurationPlaces;Lcom/algolia/search/configuration/Credentials;)Lcom/algolia/search/client/ClientPlaces;
+	public static final fun ClientPlaces (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;)Lcom/algolia/search/client/ClientPlaces;
+	public static synthetic fun ClientPlaces$default (Lcom/algolia/search/configuration/ConfigurationPlaces;Lcom/algolia/search/configuration/Credentials;ILjava/lang/Object;)Lcom/algolia/search/client/ClientPlaces;
+}
+
+public abstract interface class com/algolia/search/client/ClientRecommend : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials, com/algolia/search/endpoint/EndpointRecommend {
+	public static final field Companion Lcom/algolia/search/client/ClientRecommend$Companion;
+}
+
+public final class com/algolia/search/client/ClientRecommend$Companion {
+}
+
+public final class com/algolia/search/client/ClientRecommend$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/client/ClientRecommend;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/client/ClientRecommendKt {
+	public static final fun ClientRecommend (Lcom/algolia/search/configuration/ConfigurationRecommend;)Lcom/algolia/search/client/ClientRecommend;
+	public static final fun ClientRecommend (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lio/ktor/client/features/logging/LogLevel;)Lcom/algolia/search/client/ClientRecommend;
+	public static synthetic fun ClientRecommend$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lio/ktor/client/features/logging/LogLevel;ILjava/lang/Object;)Lcom/algolia/search/client/ClientRecommend;
+}
+
+public abstract interface class com/algolia/search/client/ClientSearch : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials, com/algolia/search/endpoint/EndpointAPIKey, com/algolia/search/endpoint/EndpointDictionary, com/algolia/search/endpoint/EndpointMultiCluster, com/algolia/search/endpoint/EndpointMultipleIndex {
+	public static final field Companion Lcom/algolia/search/client/ClientSearch$Companion;
+	public abstract fun getLogs (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/LogType;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getTask (Lcom/algolia/search/model/task/AppTaskID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun initIndex (Lcom/algolia/search/model/IndexName;)Lcom/algolia/search/client/Index;
+	public abstract fun wait (Lcom/algolia/search/model/response/ResponseDictionary;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun wait (Lcom/algolia/search/model/response/creation/CreationAPIKey;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun wait (Lcom/algolia/search/model/response/deletion/DeletionAPIKey;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitAll (Lcom/algolia/search/model/response/ResponseBatches;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitAll (Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitTask (Lcom/algolia/search/model/task/AppTaskID;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/client/ClientSearch$Companion {
+	public final fun generateAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;)Lcom/algolia/search/model/APIKey;
+	public final fun getSecuredApiKeyRemainingValidity (Lcom/algolia/search/model/APIKey;)J
+}
+
+public final class com/algolia/search/client/ClientSearch$DefaultImpls {
+	public static synthetic fun getLogs$default (Lcom/algolia/search/client/ClientSearch;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/LogType;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getTask$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/task/AppTaskID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getTimeout (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+	public static synthetic fun wait$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/response/ResponseDictionary;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun wait$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/response/creation/CreationAPIKey;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun wait$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/response/deletion/DeletionAPIKey;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun waitAll$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/response/ResponseBatches;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun waitAll$default (Lcom/algolia/search/client/ClientSearch;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun waitTask$default (Lcom/algolia/search/client/ClientSearch;Lcom/algolia/search/model/task/AppTaskID;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/client/ClientSearchKt {
+	public static final fun ClientSearch (Lcom/algolia/search/configuration/ConfigurationSearch;)Lcom/algolia/search/client/ClientSearch;
+	public static final fun ClientSearch (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lio/ktor/client/features/logging/LogLevel;)Lcom/algolia/search/client/ClientSearch;
+	public static synthetic fun ClientSearch$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lio/ktor/client/features/logging/LogLevel;ILjava/lang/Object;)Lcom/algolia/search/client/ClientSearch;
+}
+
+public abstract interface class com/algolia/search/client/Index : com/algolia/search/endpoint/EndpointAdvanced, com/algolia/search/endpoint/EndpointAnswers, com/algolia/search/endpoint/EndpointIndex, com/algolia/search/endpoint/EndpointIndexing, com/algolia/search/endpoint/EndpointRule, com/algolia/search/endpoint/EndpointSearch, com/algolia/search/endpoint/EndpointSettings, com/algolia/search/endpoint/EndpointSynonym {
+	public static final field Companion Lcom/algolia/search/client/Index$Companion;
+	public abstract fun browseObjects (Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun browseRules (Lcom/algolia/search/model/rule/RuleQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun browseSynonyms (Lcom/algolia/search/model/synonym/SynonymQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+}
+
+public final class com/algolia/search/client/Index$Companion {
+}
+
+public final class com/algolia/search/client/Index$DefaultImpls {
+	public static synthetic fun browseObjects$default (Lcom/algolia/search/client/Index;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun browseRules$default (Lcom/algolia/search/client/Index;Lcom/algolia/search/model/rule/RuleQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun browseSynonyms$default (Lcom/algolia/search/client/Index;Lcom/algolia/search/model/synonym/SynonymQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/configuration/AlgoliaSearchClient {
+	public static final field INSTANCE Lcom/algolia/search/configuration/AlgoliaSearchClient;
+	public static final field version Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/CallType : java/lang/Enum {
+	public static final field Read Lcom/algolia/search/configuration/CallType;
+	public static final field Write Lcom/algolia/search/configuration/CallType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/configuration/CallType;
+	public static fun values ()[Lcom/algolia/search/configuration/CallType;
+}
+
+public final class com/algolia/search/configuration/Compression : java/lang/Enum {
+	public static final field Gzip Lcom/algolia/search/configuration/Compression;
+	public static final field None Lcom/algolia/search/configuration/Compression;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/configuration/Compression;
+	public static fun values ()[Lcom/algolia/search/configuration/Compression;
+}
+
+public abstract interface class com/algolia/search/configuration/Configuration {
+	public abstract fun getCompression ()Lcom/algolia/search/configuration/Compression;
+	public abstract fun getDefaultHeaders ()Ljava/util/Map;
+	public abstract fun getEngine ()Lio/ktor/client/engine/HttpClientEngine;
+	public abstract fun getHosts ()Ljava/util/List;
+	public abstract fun getHttpClient ()Lio/ktor/client/HttpClient;
+	public abstract fun getHttpClientConfig ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getLogLevel ()Lio/ktor/client/features/logging/LogLevel;
+	public abstract fun getReadTimeout ()J
+	public abstract fun getTimeout (Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+	public abstract fun getWriteTimeout ()J
+}
+
+public final class com/algolia/search/configuration/Configuration$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/Configuration;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationAnalytics : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials {
+	public abstract fun getRegion ()Lcom/algolia/search/configuration/Region$Analytics;
+}
+
+public final class com/algolia/search/configuration/ConfigurationAnalytics$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationAnalytics;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationAnalyticsKt {
+	public static final fun ConfigurationAnalytics (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Analytics;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/configuration/ConfigurationAnalytics;
+	public static synthetic fun ConfigurationAnalytics$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Analytics;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationAnalytics;
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationInsights : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials {
+}
+
+public final class com/algolia/search/configuration/ConfigurationInsights$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationInsights;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationInsightsKt {
+	public static final fun ConfigurationInsights (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/configuration/ConfigurationInsights;
+	public static synthetic fun ConfigurationInsights$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationInsights;
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationPersonalization : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials {
+	public abstract fun getRegion ()Lcom/algolia/search/configuration/Region$Personalization;
+}
+
+public final class com/algolia/search/configuration/ConfigurationPersonalization$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationPersonalization;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationPersonalizationKt {
+	public static final fun ConfigurationPersonalization (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Personalization;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/configuration/ConfigurationPersonalization;
+	public static synthetic fun ConfigurationPersonalization$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Personalization;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationPersonalization;
+	public static final fun ConfigurationRecommendation (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Recommendation;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/configuration/ConfigurationPersonalization;
+	public static synthetic fun ConfigurationRecommendation$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/configuration/Region$Recommendation;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationPersonalization;
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationPlaces : com/algolia/search/configuration/Configuration {
+}
+
+public final class com/algolia/search/configuration/ConfigurationPlaces$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationPlaces;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationPlacesKt {
+	public static final fun ConfigurationPlaces (JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/configuration/ConfigurationPlaces;
+	public static synthetic fun ConfigurationPlaces$default (JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationPlaces;
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationRecommend : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials {
+}
+
+public final class com/algolia/search/configuration/ConfigurationRecommend$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationRecommend;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationRecommendKt {
+	public static final fun ConfigurationRecommend (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;Lcom/algolia/search/configuration/Compression;)Lcom/algolia/search/configuration/ConfigurationRecommend;
+	public static synthetic fun ConfigurationRecommend$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;Lcom/algolia/search/configuration/Compression;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationRecommend;
+}
+
+public abstract interface class com/algolia/search/configuration/ConfigurationSearch : com/algolia/search/configuration/Configuration, com/algolia/search/configuration/Credentials {
+}
+
+public final class com/algolia/search/configuration/ConfigurationSearch$DefaultImpls {
+	public static fun getTimeout (Lcom/algolia/search/configuration/ConfigurationSearch;Lcom/algolia/search/transport/RequestOptions;Lcom/algolia/search/configuration/CallType;)J
+}
+
+public final class com/algolia/search/configuration/ConfigurationSearchKt {
+	public static final fun ConfigurationSearch (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;Lcom/algolia/search/configuration/Compression;)Lcom/algolia/search/configuration/ConfigurationSearch;
+	public static synthetic fun ConfigurationSearch$default (Lcom/algolia/search/model/ApplicationID;Lcom/algolia/search/model/APIKey;JJLio/ktor/client/features/logging/LogLevel;Ljava/util/List;Ljava/util/Map;Lio/ktor/client/engine/HttpClientEngine;Lkotlin/jvm/functions/Function1;Lcom/algolia/search/configuration/Compression;ILjava/lang/Object;)Lcom/algolia/search/configuration/ConfigurationSearch;
+}
+
+public abstract interface class com/algolia/search/configuration/Credentials {
+	public abstract fun getApiKey ()Lcom/algolia/search/model/APIKey;
+	public abstract fun getApplicationID ()Lcom/algolia/search/model/ApplicationID;
+}
+
+public abstract class com/algolia/search/configuration/Region {
+}
+
+public abstract class com/algolia/search/configuration/Region$Analytics : com/algolia/search/model/internal/Raw {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Analytics$EU : com/algolia/search/configuration/Region$Analytics {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Analytics$EU;
+}
+
+public final class com/algolia/search/configuration/Region$Analytics$Other : com/algolia/search/configuration/Region$Analytics {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Analytics$US : com/algolia/search/configuration/Region$Analytics {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Analytics$US;
+}
+
+public abstract class com/algolia/search/configuration/Region$Personalization : com/algolia/search/model/internal/Raw {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Personalization$EU : com/algolia/search/configuration/Region$Personalization {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Personalization$EU;
+}
+
+public final class com/algolia/search/configuration/Region$Personalization$Other : com/algolia/search/configuration/Region$Personalization {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Personalization$US : com/algolia/search/configuration/Region$Personalization {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Personalization$US;
+}
+
+public abstract class com/algolia/search/configuration/Region$Recommendation : com/algolia/search/model/internal/Raw {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Recommendation$EU : com/algolia/search/configuration/Region$Recommendation {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Recommendation$EU;
+}
+
+public final class com/algolia/search/configuration/Region$Recommendation$Other : com/algolia/search/configuration/Region$Recommendation {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/Region$Recommendation$US : com/algolia/search/configuration/Region$Recommendation {
+	public static final field INSTANCE Lcom/algolia/search/configuration/Region$Recommendation$US;
+}
+
+public final class com/algolia/search/configuration/RetryableHost {
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/configuration/CallType;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/algolia/search/configuration/CallType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/configuration/CallType;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/configuration/CallType;)Lcom/algolia/search/configuration/RetryableHost;
+	public static synthetic fun copy$default (Lcom/algolia/search/configuration/RetryableHost;Ljava/lang/String;Lcom/algolia/search/configuration/CallType;ILjava/lang/Object;)Lcom/algolia/search/configuration/RetryableHost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCallType ()Lcom/algolia/search/configuration/CallType;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/configuration/UserAgentKt {
+	public static final fun clientUserAgent (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/algolia/search/dsl/DSL {
+	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/dsl/DSLDeleteByQueryKt {
+	public static final fun deleteByQuery (Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/indexing/DeleteByQuery;
+	public static final fun facetFilters (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun filters (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun insideBoundingBox (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun insidePolygon (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun numericFilters (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun tagFilters (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/algolia/search/dsl/DSLKt {
+	public static final fun getAll ()Lcom/algolia/search/model/Attribute;
+	public static final fun objectIDs (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun requestOptions (Lcom/algolia/search/transport/RequestOptions;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/transport/RequestOptions;
+	public static synthetic fun requestOptions$default (Lcom/algolia/search/transport/RequestOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/transport/RequestOptions;
+}
+
+public final class com/algolia/search/dsl/DSLObjectIDs {
+	public static final field Companion Lcom/algolia/search/dsl/DSLObjectIDs$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/ObjectID;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/DSLObjectIDs$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public abstract interface annotation class com/algolia/search/dsl/DSLParameters : java/lang/annotation/Annotation {
+}
+
+public final class com/algolia/search/dsl/DSLPlacesQueryKt {
+	public static final fun countries (Lcom/algolia/search/model/places/PlacesQuery;Lkotlin/jvm/functions/Function1;)V
+	public static final fun placesQuery (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/places/PlacesQuery;
+	public static synthetic fun placesQuery$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/model/places/PlacesQuery;
+}
+
+public final class com/algolia/search/dsl/DSLQueryKt {
+	public static final fun advancedSyntaxFeatures (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun alternativesAsExact (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun analyticsTags (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToHighlight (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToRetrieve (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToSnippet (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disableExactOnAttributes (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disableTypoToleranceOnAttributes (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun explainModules (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun facetFilters (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun facetFilters$default (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun facets (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun filters (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun insideBoundingBox (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun insidePolygon (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun naturalLanguages (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun numericFilters (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun numericFilters$default (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun optionalFilters (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun optionalFilters$default (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun optionalWords (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun query (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/search/Query;
+	public static synthetic fun query$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/model/search/Query;
+	public static final fun queryLanguages (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun responseFields (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun restrictSearchableAttributes (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun ruleContexts (Lcom/algolia/search/model/search/Query;Lkotlin/jvm/functions/Function1;)V
+	public static final fun tagFilters (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun tagFilters$default (Lcom/algolia/search/model/search/Query;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class com/algolia/search/dsl/DSLRuleQueryKt {
+	public static final fun ruleQuery (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/rule/RuleQuery;
+	public static synthetic fun ruleQuery$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/algolia/search/model/rule/RuleQuery;
+}
+
+public final class com/algolia/search/dsl/DSLSettingsKey {
+	public static final field Companion Lcom/algolia/search/dsl/DSLSettingsKey$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAdvancedSyntax ()Lcom/algolia/search/model/settings/SettingsKey$AdvancedSyntax;
+	public final fun getAllowCompressionOfIntegerArray ()Lcom/algolia/search/model/settings/SettingsKey$AllowCompressionOfIntegerArray;
+	public final fun getAllowTyposOnNumericTokens ()Lcom/algolia/search/model/settings/SettingsKey$AllowTyposOnNumericTokens;
+	public final fun getAlternativesAsExact ()Lcom/algolia/search/model/settings/SettingsKey$AlternativesAsExact;
+	public final fun getAttributeForDistinct ()Lcom/algolia/search/model/settings/SettingsKey$AttributeForDistinct;
+	public final fun getAttributesForFaceting ()Lcom/algolia/search/model/settings/SettingsKey$AttributesForFaceting;
+	public final fun getAttributesToHighlight ()Lcom/algolia/search/model/settings/SettingsKey$AttributesToHighlight;
+	public final fun getAttributesToRetrieve ()Lcom/algolia/search/model/settings/SettingsKey$AttributesToRetrieve;
+	public final fun getAttributesToSnippet ()Lcom/algolia/search/model/settings/SettingsKey$AttributesToSnippet;
+	public final fun getCamelCaseAttributes ()Lcom/algolia/search/model/settings/SettingsKey$CamelCaseAttributes;
+	public final fun getCustomRanking ()Lcom/algolia/search/model/settings/SettingsKey$CustomRanking;
+	public final fun getDecompoundedAttributes ()Lcom/algolia/search/model/settings/SettingsKey$DecompoundedAttributes;
+	public final fun getDisableExactOnAttributes ()Lcom/algolia/search/model/settings/SettingsKey$DisableExactOnAttributes;
+	public final fun getDisablePrefixOnAttributes ()Lcom/algolia/search/model/settings/SettingsKey$DisablePrefixOnAttributes;
+	public final fun getDisableTypoToleranceOnAttributes ()Lcom/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnAttributes;
+	public final fun getDisableTypoToleranceOnWords ()Lcom/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnWords;
+	public final fun getDistinct ()Lcom/algolia/search/model/settings/SettingsKey$Distinct;
+	public final fun getEnableRules ()Lcom/algolia/search/model/settings/SettingsKey$EnableRules;
+	public final fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/settings/SettingsKey$ExactOnSingleWordQuery;
+	public final fun getHighlightPostTag ()Lcom/algolia/search/model/settings/SettingsKey$HighlightPostTag;
+	public final fun getHighlightPreTag ()Lcom/algolia/search/model/settings/SettingsKey$HighlightPreTag;
+	public final fun getHitsPerPage ()Lcom/algolia/search/model/settings/SettingsKey$HitsPerPage;
+	public final fun getIgnorePlurals ()Lcom/algolia/search/model/settings/SettingsKey$IgnorePlurals;
+	public final fun getKeepDiacriticsOnCharacters ()Lcom/algolia/search/model/settings/SettingsKey$KeepDiacriticsOnCharacters;
+	public final fun getMaxFacetHits ()Lcom/algolia/search/model/settings/SettingsKey$MaxFacetHits;
+	public final fun getMaxValuesPerFacet ()Lcom/algolia/search/model/settings/SettingsKey$MaxValuesPerFacet;
+	public final fun getMinProximity ()Lcom/algolia/search/model/settings/SettingsKey$MinProximity;
+	public final fun getMinWordSizefor1Typo ()Lcom/algolia/search/model/settings/SettingsKey$MinWordSizefor1Typo;
+	public final fun getMinWordSizefor2Typos ()Lcom/algolia/search/model/settings/SettingsKey$MinWordSizefor2Typos;
+	public final fun getNumericAttributesForFiltering ()Lcom/algolia/search/model/settings/SettingsKey$NumericAttributesForFiltering;
+	public final fun getOptionalWords ()Lcom/algolia/search/model/settings/SettingsKey$OptionalWords;
+	public final fun getPaginationLimitedTo ()Lcom/algolia/search/model/settings/SettingsKey$PaginationLimitedTo;
+	public final fun getQueryLanguages ()Lcom/algolia/search/model/settings/SettingsKey$QueryLanguages;
+	public final fun getQueryType ()Lcom/algolia/search/model/settings/SettingsKey$QueryType;
+	public final fun getRanking ()Lcom/algolia/search/model/settings/SettingsKey$Ranking;
+	public final fun getRemoveStopWords ()Lcom/algolia/search/model/settings/SettingsKey$RemoveStopWords;
+	public final fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/settings/SettingsKey$RemoveWordsIfNoResults;
+	public final fun getReplaceSynonymsInHighlight ()Lcom/algolia/search/model/settings/SettingsKey$ReplaceSynonymsInHighlight;
+	public final fun getReplicas ()Lcom/algolia/search/model/settings/SettingsKey$Replicas;
+	public final fun getResponseFields ()Lcom/algolia/search/model/settings/SettingsKey$ResponseFields;
+	public final fun getRestrictHighlightAndSnippetArrays ()Lcom/algolia/search/model/settings/SettingsKey$RestrictHighlightAndSnippetArrays;
+	public final fun getSearchableAttributes ()Lcom/algolia/search/model/settings/SettingsKey$SearchableAttributes;
+	public final fun getSeparatorsToIndex ()Lcom/algolia/search/model/settings/SettingsKey$SeparatorsToIndex;
+	public final fun getSnippetEllipsisText ()Lcom/algolia/search/model/settings/SettingsKey$SnippetEllipsisText;
+	public final fun getSortFacetsBy ()Lcom/algolia/search/model/settings/SettingsKey$SortFacetsBy;
+	public final fun getTypoTolerance ()Lcom/algolia/search/model/settings/SettingsKey$TypoTolerance;
+	public final fun getUnretrievableAttributes ()Lcom/algolia/search/model/settings/SettingsKey$UnretrievableAttributes;
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/SettingsKey;)V
+}
+
+public final class com/algolia/search/dsl/DSLSettingsKey$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/DSLSettingsKt {
+	public static final fun advancedSyntaxFeatures (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun alternativesAsExact (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesForFaceting (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToHighlight (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToRetrieve (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun attributesToSnippet (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun camelCaseAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun customRanking (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun decompoundedAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disableExactOnAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disablePrefixOnAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disableTypoToleranceOnAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun disableTypoToleranceOnWords (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun indexLanguages (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun numericAttributesForFiltering (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun optionalWords (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun queryLanguages (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun ranking (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun replicas (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun responseFields (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun searchableAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+	public static final fun settings (Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/settings/Settings;
+	public static final fun settingsKey (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun unretrieveableAttributes (Lcom/algolia/search/model/settings/Settings;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/algolia/search/dsl/DSLStrings {
+	public static final field Companion Lcom/algolia/search/dsl/DSLStrings$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/DSLStrings$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/DSLSynonymQueryKt {
+	public static final fun synonymQuery (Lkotlin/jvm/functions/Function1;)Lcom/algolia/search/model/synonym/SynonymQuery;
+	public static final fun synonymTypes (Lcom/algolia/search/model/synonym/SynonymQuery;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/algolia/search/dsl/DSLSynonymType {
+	public static final field Companion Lcom/algolia/search/dsl/DSLSynonymType$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAlternativeCorrectionsOneTypo ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public final fun getAlternativeCorrectionsTwoTypos ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public final fun getMultiWay ()Lcom/algolia/search/model/synonym/SynonymType$MultiWay;
+	public final fun getOneWay ()Lcom/algolia/search/model/synonym/SynonymType$OneWay;
+	public final fun getPlaceholder ()Lcom/algolia/search/model/synonym/SynonymType$Placeholder;
+	public final fun unaryPlus (Lcom/algolia/search/model/synonym/SynonymType$Typo;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/synonym/SynonymType;)V
+}
+
+public final class com/algolia/search/dsl/DSLSynonymType$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/advanced/DSLExplainModules {
+	public static final field Companion Lcom/algolia/search/dsl/advanced/DSLExplainModules$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMatchAlternatives ()Lcom/algolia/search/model/search/ExplainModule$MatchAlternatives;
+	public final fun unaryPlus (Lcom/algolia/search/model/search/ExplainModule;)V
+}
+
+public final class com/algolia/search/dsl/advanced/DSLExplainModules$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/advanced/DSLResponseFields {
+	public static final field Companion Lcom/algolia/search/dsl/advanced/DSLResponseFields$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAll ()Lcom/algolia/search/model/search/ResponseFields$All;
+	public final fun getAroundLatLng ()Lcom/algolia/search/model/search/ResponseFields$AroundLatLng;
+	public final fun getAutomaticRadius ()Lcom/algolia/search/model/search/ResponseFields$AutomaticRadius;
+	public final fun getExhaustiveFacetsCount ()Lcom/algolia/search/model/search/ResponseFields$ExhaustiveFacetsCount;
+	public final fun getFacets ()Lcom/algolia/search/model/search/ResponseFields$Facets;
+	public final fun getFacetsStats ()Lcom/algolia/search/model/search/ResponseFields$FacetsStats;
+	public final fun getHits ()Lcom/algolia/search/model/search/ResponseFields$Hits;
+	public final fun getHitsPerPage ()Lcom/algolia/search/model/search/ResponseFields$HitsPerPage;
+	public final fun getIndex ()Lcom/algolia/search/model/search/ResponseFields$Index;
+	public final fun getLength ()Lcom/algolia/search/model/search/ResponseFields$Length;
+	public final fun getNbHits ()Lcom/algolia/search/model/search/ResponseFields$NbHits;
+	public final fun getNbPages ()Lcom/algolia/search/model/search/ResponseFields$NbPages;
+	public final fun getOffset ()Lcom/algolia/search/model/search/ResponseFields$Offset;
+	public final fun getPage ()Lcom/algolia/search/model/search/ResponseFields$Page;
+	public final fun getParams ()Lcom/algolia/search/model/search/ResponseFields$Params;
+	public final fun getProcessingTimeMS ()Lcom/algolia/search/model/search/ResponseFields$ProcessingTimeMS;
+	public final fun getQuery ()Lcom/algolia/search/model/search/ResponseFields$Query;
+	public final fun getQueryAfterRemoval ()Lcom/algolia/search/model/search/ResponseFields$QueryAfterRemoval;
+	public final fun getUserData ()Lcom/algolia/search/model/search/ResponseFields$UserData;
+	public final fun unaryPlus (Lcom/algolia/search/model/search/ResponseFields;)V
+}
+
+public final class com/algolia/search/dsl/advanced/DSLResponseFields$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributes {
+	public static final field Companion Lcom/algolia/search/dsl/attributes/DSLAttributes$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributes$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesForFaceting {
+	public static final field Companion Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFilterOnly ()Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+	public final fun getSearchable ()Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+	public final fun invoke (Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/AttributeForFaceting;
+	public final fun invoke (Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;Ljava/lang/String;)Lcom/algolia/search/model/settings/AttributeForFaceting;
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/AttributeForFaceting;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesForFaceting$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier : java/lang/Enum {
+	public static final field FilterOnly Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+	public static final field Searchable Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+	public static fun values ()[Lcom/algolia/search/dsl/attributes/DSLAttributesForFaceting$Modifier;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesSet {
+	public static final field Companion Lcom/algolia/search/dsl/attributes/DSLAttributesSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesSet$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesToRetrieve {
+	public static final field Companion Lcom/algolia/search/dsl/attributes/DSLAttributesToRetrieve$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExcludeAttributes ()Z
+	public final fun setExcludeAttributes (Z)V
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/attributes/DSLAttributesToRetrieve$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLSearchableAttributes {
+	public static final field Companion Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getUnordered ()Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;
+	public final fun invoke (Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/SearchableAttribute;
+	public final fun invoke (Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;Ljava/lang/String;)Lcom/algolia/search/model/settings/SearchableAttribute;
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/SearchableAttribute;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/attributes/DSLSearchableAttributes$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier : java/lang/Enum {
+	public static final field Unordered Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;
+	public static fun values ()[Lcom/algolia/search/dsl/attributes/DSLSearchableAttributes$Modifier;
+}
+
+public abstract interface class com/algolia/search/dsl/filtering/DSLFacet {
+	public abstract fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public abstract fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public abstract fun facet (Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;Z)V
+	public abstract fun facet (Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public abstract fun facet (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public abstract fun facet (Ljava/lang/String;ZLjava/lang/Integer;Z)V
+	public abstract fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Facet;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLFacet$DefaultImpls {
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;Z)V
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public static fun facet (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;ZLjava/lang/Integer;Z)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;ZILjava/lang/Object;)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;ZILjava/lang/Object;)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Integer;ZILjava/lang/Object;)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)V
+	public static synthetic fun facet$default (Lcom/algolia/search/dsl/filtering/DSLFacet;Ljava/lang/String;ZLjava/lang/Integer;ZILjava/lang/Object;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLFacetFilters {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLFacetFilters$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun and (Lkotlin/jvm/functions/Function1;)V
+	public final fun or (Lkotlin/jvm/functions/Function1;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/filter/FilterGroup;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLFacetFilters$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/filtering/DSLFilters {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLFilters$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun and (Lkotlin/jvm/functions/Function1;)V
+	public final fun orFacet (Lkotlin/jvm/functions/Function1;)V
+	public final fun orNumeric (Lkotlin/jvm/functions/Function1;)V
+	public final fun orTag (Lkotlin/jvm/functions/Function1;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/filter/FilterGroup;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLFilters$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public abstract class com/algolia/search/dsl/filtering/DSLGroup {
+	protected abstract fun getFilters ()Ljava/util/Set;
+	public final fun unaryPlus (Lcom/algolia/search/model/filter/Filter;)V
+	public final fun unaryPlus (Ljava/util/Collection;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupFacet : com/algolia/search/dsl/filtering/DSLGroup, com/algolia/search/dsl/filtering/DSLFacet {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLGroupFacet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public fun facet (Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;ZLjava/lang/Integer;Z)V
+	public synthetic fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Facet;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupFacet$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupFilter : com/algolia/search/dsl/filtering/DSLGroup, com/algolia/search/dsl/filtering/DSLFacet, com/algolia/search/dsl/filtering/DSLNumeric, com/algolia/search/dsl/filtering/DSLTag {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLGroupFilter$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun comparison (Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public fun comparison (Ljava/lang/String;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public fun facet (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public fun facet (Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public fun facet (Ljava/lang/String;ZLjava/lang/Integer;Z)V
+	public fun getEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getGreater ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getGreaterOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getLess ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getLessOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getNotEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun range (Lcom/algolia/search/model/Attribute;DDZ)V
+	public fun range (Lcom/algolia/search/model/Attribute;FFZ)V
+	public fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;Z)V
+	public fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;Z)V
+	public fun range (Ljava/lang/String;DDZ)V
+	public fun range (Ljava/lang/String;FFZ)V
+	public fun range (Ljava/lang/String;Lkotlin/ranges/IntRange;Z)V
+	public fun range (Ljava/lang/String;Lkotlin/ranges/LongRange;Z)V
+	public fun tag (Ljava/lang/String;Z)V
+	public fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Facet;)V
+	public fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Numeric;)V
+	public fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Tag;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupFilter$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupNumeric : com/algolia/search/dsl/filtering/DSLGroup, com/algolia/search/dsl/filtering/DSLNumeric {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLGroupNumeric$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun comparison (Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public fun comparison (Ljava/lang/String;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public fun getEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getGreater ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getGreaterOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getLess ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getLessOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun getNotEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun range (Lcom/algolia/search/model/Attribute;DDZ)V
+	public fun range (Lcom/algolia/search/model/Attribute;FFZ)V
+	public fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;Z)V
+	public fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;Z)V
+	public fun range (Ljava/lang/String;DDZ)V
+	public fun range (Ljava/lang/String;FFZ)V
+	public fun range (Ljava/lang/String;Lkotlin/ranges/IntRange;Z)V
+	public fun range (Ljava/lang/String;Lkotlin/ranges/LongRange;Z)V
+	public synthetic fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Numeric;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupNumeric$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupTag : com/algolia/search/dsl/filtering/DSLGroup, com/algolia/search/dsl/filtering/DSLTag {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLGroupTag$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun tag (Ljava/lang/String;Z)V
+	public synthetic fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Tag;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLGroupTag$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public abstract interface class com/algolia/search/dsl/filtering/DSLNumeric {
+	public abstract fun comparison (Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public abstract fun comparison (Ljava/lang/String;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public abstract fun getEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun getGreater ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun getGreaterOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun getLess ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun getLessOrEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun getNotEquals ()Lcom/algolia/search/model/filter/NumericOperator;
+	public abstract fun range (Lcom/algolia/search/model/Attribute;DDZ)V
+	public abstract fun range (Lcom/algolia/search/model/Attribute;FFZ)V
+	public abstract fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;Z)V
+	public abstract fun range (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;Z)V
+	public abstract fun range (Ljava/lang/String;DDZ)V
+	public abstract fun range (Ljava/lang/String;FFZ)V
+	public abstract fun range (Ljava/lang/String;Lkotlin/ranges/IntRange;Z)V
+	public abstract fun range (Ljava/lang/String;Lkotlin/ranges/LongRange;Z)V
+	public abstract fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Numeric;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLNumeric$DefaultImpls {
+	public static fun comparison (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public static fun comparison (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public static synthetic fun comparison$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;ZILjava/lang/Object;)V
+	public static synthetic fun comparison$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;ZILjava/lang/Object;)V
+	public static fun getEquals (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun getGreater (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun getGreaterOrEquals (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun getLess (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun getLessOrEquals (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun getNotEquals (Lcom/algolia/search/dsl/filtering/DSLNumeric;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;DDZ)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;FFZ)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;Z)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;Z)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;DDZ)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;FFZ)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lkotlin/ranges/IntRange;Z)V
+	public static fun range (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lkotlin/ranges/LongRange;Z)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;DDZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;FFZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;ZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;ZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;DDZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;FFZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lkotlin/ranges/IntRange;ZILjava/lang/Object;)V
+	public static synthetic fun range$default (Lcom/algolia/search/dsl/filtering/DSLNumeric;Ljava/lang/String;Lkotlin/ranges/LongRange;ZILjava/lang/Object;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLNumericFilters {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLNumericFilters$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun and (Lkotlin/jvm/functions/Function1;)V
+	public final fun or (Lkotlin/jvm/functions/Function1;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/filter/FilterGroup;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLNumericFilters$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public abstract interface class com/algolia/search/dsl/filtering/DSLTag {
+	public abstract fun tag (Ljava/lang/String;Z)V
+	public abstract fun unaryPlus (Lcom/algolia/search/model/filter/Filter$Tag;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLTag$DefaultImpls {
+	public static fun tag (Lcom/algolia/search/dsl/filtering/DSLTag;Ljava/lang/String;Z)V
+	public static synthetic fun tag$default (Lcom/algolia/search/dsl/filtering/DSLTag;Ljava/lang/String;ZILjava/lang/Object;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLTagFilters {
+	public static final field Companion Lcom/algolia/search/dsl/filtering/DSLTagFilters$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun and (Lkotlin/jvm/functions/Function1;)V
+	public final fun or (Lkotlin/jvm/functions/Function1;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/filter/FilterGroup;)V
+}
+
+public final class com/algolia/search/dsl/filtering/DSLTagFilters$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
+}
+
+public final class com/algolia/search/dsl/geosearch/DSLBoundingBox {
+	public static final field Companion Lcom/algolia/search/dsl/geosearch/DSLBoundingBox$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/search/BoundingBox;)V
+}
+
+public final class com/algolia/search/dsl/geosearch/DSLBoundingBox$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/geosearch/DSLPolygon {
+	public static final field Companion Lcom/algolia/search/dsl/geosearch/DSLPolygon$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/search/Polygon;)V
+}
+
+public final class com/algolia/search/dsl/geosearch/DSLPolygon$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/highlighting/DSLSnippet {
+	public static final field Companion Lcom/algolia/search/dsl/highlighting/DSLSnippet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun invoke (Lcom/algolia/search/model/Attribute;I)Lcom/algolia/search/model/search/Snippet;
+	public final fun invoke (Ljava/lang/String;I)Lcom/algolia/search/model/search/Snippet;
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/search/Snippet;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/highlighting/DSLSnippet$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/languages/DSLDecompoundedAttributes {
+	public static final field Companion Lcom/algolia/search/dsl/languages/DSLDecompoundedAttributes$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun dutch (Lkotlin/jvm/functions/Function1;)V
+	public final fun finnish (Lkotlin/jvm/functions/Function1;)V
+	public final fun german (Lkotlin/jvm/functions/Function1;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/DecompoundedAttributes;)V
+}
+
+public final class com/algolia/search/dsl/languages/DSLDecompoundedAttributes$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/languages/DSLKt {
+	public static final fun languages (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/languages/DSLLanguage {
+	public static final field Companion Lcom/algolia/search/dsl/languages/DSLLanguage$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAfrikaans ()Lcom/algolia/search/model/search/Language$Afrikaans;
+	public final fun getAlbanian ()Lcom/algolia/search/model/search/Language$Albanian;
+	public final fun getArabic ()Lcom/algolia/search/model/search/Language$Arabic;
+	public final fun getArmenian ()Lcom/algolia/search/model/search/Language$Armenian;
+	public final fun getAzeri ()Lcom/algolia/search/model/search/Language$Azeri;
+	public final fun getBasque ()Lcom/algolia/search/model/search/Language$Basque;
+	public final fun getBrunei ()Lcom/algolia/search/model/search/Language$Brunei;
+	public final fun getBulgarian ()Lcom/algolia/search/model/search/Language$Bulgarian;
+	public final fun getCatalan ()Lcom/algolia/search/model/search/Language$Catalan;
+	public final fun getCzech ()Lcom/algolia/search/model/search/Language$Czech;
+	public final fun getDanish ()Lcom/algolia/search/model/search/Language$Danish;
+	public final fun getDutch ()Lcom/algolia/search/model/search/Language$Dutch;
+	public final fun getEnglish ()Lcom/algolia/search/model/search/Language$English;
+	public final fun getEsperanto ()Lcom/algolia/search/model/search/Language$Esperanto;
+	public final fun getEstonian ()Lcom/algolia/search/model/search/Language$Estonian;
+	public final fun getFaroese ()Lcom/algolia/search/model/search/Language$Faroese;
+	public final fun getFinnish ()Lcom/algolia/search/model/search/Language$Finnish;
+	public final fun getFrench ()Lcom/algolia/search/model/search/Language$French;
+	public final fun getGalician ()Lcom/algolia/search/model/search/Language$Galician;
+	public final fun getGeorgian ()Lcom/algolia/search/model/search/Language$Georgian;
+	public final fun getGerman ()Lcom/algolia/search/model/search/Language$German;
+	public final fun getHebrew ()Lcom/algolia/search/model/search/Language$Hebrew;
+	public final fun getHindi ()Lcom/algolia/search/model/search/Language$Hindi;
+	public final fun getHungarian ()Lcom/algolia/search/model/search/Language$Hungarian;
+	public final fun getIcelandic ()Lcom/algolia/search/model/search/Language$Icelandic;
+	public final fun getIndonesian ()Lcom/algolia/search/model/search/Language$Indonesian;
+	public final fun getItalian ()Lcom/algolia/search/model/search/Language$Italian;
+	public final fun getJapanese ()Lcom/algolia/search/model/search/Language$Japanese;
+	public final fun getKazakh ()Lcom/algolia/search/model/search/Language$Kazakh;
+	public final fun getKorean ()Lcom/algolia/search/model/search/Language$Korean;
+	public final fun getKyrgyz ()Lcom/algolia/search/model/search/Language$Kyrgyz;
+	public final fun getLithuanian ()Lcom/algolia/search/model/search/Language$Lithuanian;
+	public final fun getMalay ()Lcom/algolia/search/model/search/Language$Malay;
+	public final fun getMaltese ()Lcom/algolia/search/model/search/Language$Maltese;
+	public final fun getMaori ()Lcom/algolia/search/model/search/Language$Maori;
+	public final fun getMarathi ()Lcom/algolia/search/model/search/Language$Marathi;
+	public final fun getMongolian ()Lcom/algolia/search/model/search/Language$Mongolian;
+	public final fun getNorthernSotho ()Lcom/algolia/search/model/search/Language$NorthernSotho;
+	public final fun getNorwegian ()Lcom/algolia/search/model/search/Language$Norwegian;
+	public final fun getPashto ()Lcom/algolia/search/model/search/Language$Pashto;
+	public final fun getPolish ()Lcom/algolia/search/model/search/Language$Polish;
+	public final fun getPortuguese ()Lcom/algolia/search/model/search/Language$Portuguese;
+	public final fun getQuechua ()Lcom/algolia/search/model/search/Language$Quechua;
+	public final fun getRomanian ()Lcom/algolia/search/model/search/Language$Romanian;
+	public final fun getRussian ()Lcom/algolia/search/model/search/Language$Russian;
+	public final fun getSlovak ()Lcom/algolia/search/model/search/Language$Slovak;
+	public final fun getSpanish ()Lcom/algolia/search/model/search/Language$Spanish;
+	public final fun getSwahili ()Lcom/algolia/search/model/search/Language$Swahili;
+	public final fun getSwedish ()Lcom/algolia/search/model/search/Language$Swedish;
+	public final fun getTagalog ()Lcom/algolia/search/model/search/Language$Tagalog;
+	public final fun getTamil ()Lcom/algolia/search/model/search/Language$Tamil;
+	public final fun getTatar ()Lcom/algolia/search/model/search/Language$Tatar;
+	public final fun getTelugu ()Lcom/algolia/search/model/search/Language$Telugu;
+	public final fun getTswana ()Lcom/algolia/search/model/search/Language$Tswana;
+	public final fun getTurkish ()Lcom/algolia/search/model/search/Language$Turkish;
+	public final fun getWelsh ()Lcom/algolia/search/model/search/Language$Welsh;
+	public final fun unaryPlus (Lcom/algolia/search/model/search/Language;)V
+}
+
+public final class com/algolia/search/dsl/languages/DSLLanguage$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/performance/DSLNumericAttributeFilter {
+	public static final field Companion Lcom/algolia/search/dsl/performance/DSLNumericAttributeFilter$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun invoke (Lcom/algolia/search/model/Attribute;Z)Lcom/algolia/search/model/settings/NumericAttributeFilter;
+	public final fun invoke (Ljava/lang/String;Z)Lcom/algolia/search/model/settings/NumericAttributeFilter;
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/NumericAttributeFilter;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/performance/DSLNumericAttributeFilter$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/places/DSLCountries {
+	public static final field Companion Lcom/algolia/search/dsl/places/DSLCountries$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAfghanistan ()Lcom/algolia/search/model/places/Country$Afghanistan;
+	public final fun getAlandIslands ()Lcom/algolia/search/model/places/Country$AlandIslands;
+	public final fun getAlbania ()Lcom/algolia/search/model/places/Country$Albania;
+	public final fun getAlgeria ()Lcom/algolia/search/model/places/Country$Algeria;
+	public final fun getAmericanSamoa ()Lcom/algolia/search/model/places/Country$AmericanSamoa;
+	public final fun getAndorra ()Lcom/algolia/search/model/places/Country$Andorra;
+	public final fun getAngola ()Lcom/algolia/search/model/places/Country$Angola;
+	public final fun getAnguilla ()Lcom/algolia/search/model/places/Country$Anguilla;
+	public final fun getAntarctica ()Lcom/algolia/search/model/places/Country$Antarctica;
+	public final fun getAntiguaAndBarbuda ()Lcom/algolia/search/model/places/Country$AntiguaAndBarbuda;
+	public final fun getArgentina ()Lcom/algolia/search/model/places/Country$Argentina;
+	public final fun getArmenia ()Lcom/algolia/search/model/places/Country$Armenia;
+	public final fun getAruba ()Lcom/algolia/search/model/places/Country$Aruba;
+	public final fun getAustralia ()Lcom/algolia/search/model/places/Country$Australia;
+	public final fun getAustria ()Lcom/algolia/search/model/places/Country$Austria;
+	public final fun getAzerbaijan ()Lcom/algolia/search/model/places/Country$Azerbaijan;
+	public final fun getBahamas ()Lcom/algolia/search/model/places/Country$Bahamas;
+	public final fun getBahrain ()Lcom/algolia/search/model/places/Country$Bahrain;
+	public final fun getBailiwickOfGuernsey ()Lcom/algolia/search/model/places/Country$BailiwickOfGuernsey;
+	public final fun getBangladesh ()Lcom/algolia/search/model/places/Country$Bangladesh;
+	public final fun getBarbados ()Lcom/algolia/search/model/places/Country$Barbados;
+	public final fun getBelarus ()Lcom/algolia/search/model/places/Country$Belarus;
+	public final fun getBelgium ()Lcom/algolia/search/model/places/Country$Belgium;
+	public final fun getBelize ()Lcom/algolia/search/model/places/Country$Belize;
+	public final fun getBenin ()Lcom/algolia/search/model/places/Country$Benin;
+	public final fun getBermuda ()Lcom/algolia/search/model/places/Country$Bermuda;
+	public final fun getBhutan ()Lcom/algolia/search/model/places/Country$Bhutan;
+	public final fun getBolivia ()Lcom/algolia/search/model/places/Country$Bolivia;
+	public final fun getBosniaAndHerzegovina ()Lcom/algolia/search/model/places/Country$BosniaAndHerzegovina;
+	public final fun getBotswana ()Lcom/algolia/search/model/places/Country$Botswana;
+	public final fun getBouvetIsland ()Lcom/algolia/search/model/places/Country$BouvetIsland;
+	public final fun getBrazil ()Lcom/algolia/search/model/places/Country$Brazil;
+	public final fun getBritishIndianOceanTerritory ()Lcom/algolia/search/model/places/Country$BritishIndianOceanTerritory;
+	public final fun getBruneiDarussalam ()Lcom/algolia/search/model/places/Country$BruneiDarussalam;
+	public final fun getBulgaria ()Lcom/algolia/search/model/places/Country$Bulgaria;
+	public final fun getBurkinaFaso ()Lcom/algolia/search/model/places/Country$BurkinaFaso;
+	public final fun getBurundi ()Lcom/algolia/search/model/places/Country$Burundi;
+	public final fun getCaboVerde ()Lcom/algolia/search/model/places/Country$CaboVerde;
+	public final fun getCambodia ()Lcom/algolia/search/model/places/Country$Cambodia;
+	public final fun getCameroon ()Lcom/algolia/search/model/places/Country$Cameroon;
+	public final fun getCanada ()Lcom/algolia/search/model/places/Country$Canada;
+	public final fun getCaribbeanNetherlands ()Lcom/algolia/search/model/places/Country$CaribbeanNetherlands;
+	public final fun getCaymanIslands ()Lcom/algolia/search/model/places/Country$CaymanIslands;
+	public final fun getCentralAfricanRepublic ()Lcom/algolia/search/model/places/Country$CentralAfricanRepublic;
+	public final fun getChad ()Lcom/algolia/search/model/places/Country$Chad;
+	public final fun getChile ()Lcom/algolia/search/model/places/Country$Chile;
+	public final fun getChina ()Lcom/algolia/search/model/places/Country$China;
+	public final fun getChristmasIsland ()Lcom/algolia/search/model/places/Country$ChristmasIsland;
+	public final fun getCocosIslands ()Lcom/algolia/search/model/places/Country$CocosIslands;
+	public final fun getColombia ()Lcom/algolia/search/model/places/Country$Colombia;
+	public final fun getComoros ()Lcom/algolia/search/model/places/Country$Comoros;
+	public final fun getCookIslands ()Lcom/algolia/search/model/places/Country$CookIslands;
+	public final fun getCostaRica ()Lcom/algolia/search/model/places/Country$CostaRica;
+	public final fun getCroatia ()Lcom/algolia/search/model/places/Country$Croatia;
+	public final fun getCuba ()Lcom/algolia/search/model/places/Country$Cuba;
+	public final fun getCuracao ()Lcom/algolia/search/model/places/Country$Curacao;
+	public final fun getCyprus ()Lcom/algolia/search/model/places/Country$Cyprus;
+	public final fun getCzechRepublic ()Lcom/algolia/search/model/places/Country$CzechRepublic;
+	public final fun getDemocraticRepublicOfTheCongo ()Lcom/algolia/search/model/places/Country$DemocraticRepublicOfTheCongo;
+	public final fun getDenmark ()Lcom/algolia/search/model/places/Country$Denmark;
+	public final fun getDjibouti ()Lcom/algolia/search/model/places/Country$Djibouti;
+	public final fun getDominica ()Lcom/algolia/search/model/places/Country$Dominica;
+	public final fun getDominicanRepublic ()Lcom/algolia/search/model/places/Country$DominicanRepublic;
+	public final fun getEcuador ()Lcom/algolia/search/model/places/Country$Ecuador;
+	public final fun getEgypt ()Lcom/algolia/search/model/places/Country$Egypt;
+	public final fun getElSalvador ()Lcom/algolia/search/model/places/Country$ElSalvador;
+	public final fun getEquatorialGuinea ()Lcom/algolia/search/model/places/Country$EquatorialGuinea;
+	public final fun getEritrea ()Lcom/algolia/search/model/places/Country$Eritrea;
+	public final fun getEstonia ()Lcom/algolia/search/model/places/Country$Estonia;
+	public final fun getEswatini ()Lcom/algolia/search/model/places/Country$Eswatini;
+	public final fun getEthiopia ()Lcom/algolia/search/model/places/Country$Ethiopia;
+	public final fun getFalklandIslands ()Lcom/algolia/search/model/places/Country$FalklandIslands;
+	public final fun getFaroeIslands ()Lcom/algolia/search/model/places/Country$FaroeIslands;
+	public final fun getFiji ()Lcom/algolia/search/model/places/Country$Fiji;
+	public final fun getFinland ()Lcom/algolia/search/model/places/Country$Finland;
+	public final fun getFrance ()Lcom/algolia/search/model/places/Country$France;
+	public final fun getFrenchGuiana ()Lcom/algolia/search/model/places/Country$FrenchGuiana;
+	public final fun getFrenchPolynesia ()Lcom/algolia/search/model/places/Country$FrenchPolynesia;
+	public final fun getFrenchSouthernAndAntarcticLands ()Lcom/algolia/search/model/places/Country$FrenchSouthernAndAntarcticLands;
+	public final fun getGabon ()Lcom/algolia/search/model/places/Country$Gabon;
+	public final fun getGambia ()Lcom/algolia/search/model/places/Country$Gambia;
+	public final fun getGeorgia ()Lcom/algolia/search/model/places/Country$Georgia;
+	public final fun getGermany ()Lcom/algolia/search/model/places/Country$Germany;
+	public final fun getGhana ()Lcom/algolia/search/model/places/Country$Ghana;
+	public final fun getGibraltar ()Lcom/algolia/search/model/places/Country$Gibraltar;
+	public final fun getGreece ()Lcom/algolia/search/model/places/Country$Greece;
+	public final fun getGreenland ()Lcom/algolia/search/model/places/Country$Greenland;
+	public final fun getGrenada ()Lcom/algolia/search/model/places/Country$Grenada;
+	public final fun getGuadeloupe ()Lcom/algolia/search/model/places/Country$Guadeloupe;
+	public final fun getGuam ()Lcom/algolia/search/model/places/Country$Guam;
+	public final fun getGuatemala ()Lcom/algolia/search/model/places/Country$Guatemala;
+	public final fun getGuinea ()Lcom/algolia/search/model/places/Country$Guinea;
+	public final fun getGuineaBissau ()Lcom/algolia/search/model/places/Country$GuineaBissau;
+	public final fun getGuyana ()Lcom/algolia/search/model/places/Country$Guyana;
+	public final fun getHaiti ()Lcom/algolia/search/model/places/Country$Haiti;
+	public final fun getHeardIslandAndMcDonaldIslands ()Lcom/algolia/search/model/places/Country$HeardIslandAndMcDonaldIslands;
+	public final fun getHonduras ()Lcom/algolia/search/model/places/Country$Honduras;
+	public final fun getHongKong ()Lcom/algolia/search/model/places/Country$HongKong;
+	public final fun getHungary ()Lcom/algolia/search/model/places/Country$Hungary;
+	public final fun getIceland ()Lcom/algolia/search/model/places/Country$Iceland;
+	public final fun getIndia ()Lcom/algolia/search/model/places/Country$India;
+	public final fun getIndonesia ()Lcom/algolia/search/model/places/Country$Indonesia;
+	public final fun getIran ()Lcom/algolia/search/model/places/Country$Iran;
+	public final fun getIraq ()Lcom/algolia/search/model/places/Country$Iraq;
+	public final fun getIreland ()Lcom/algolia/search/model/places/Country$Ireland;
+	public final fun getIsleOfMan ()Lcom/algolia/search/model/places/Country$IsleOfMan;
+	public final fun getIsrael ()Lcom/algolia/search/model/places/Country$Israel;
+	public final fun getItaly ()Lcom/algolia/search/model/places/Country$Italy;
+	public final fun getIvoryCoast ()Lcom/algolia/search/model/places/Country$IvoryCoast;
+	public final fun getJamaica ()Lcom/algolia/search/model/places/Country$Jamaica;
+	public final fun getJapan ()Lcom/algolia/search/model/places/Country$Japan;
+	public final fun getJersey ()Lcom/algolia/search/model/places/Country$Jersey;
+	public final fun getJordan ()Lcom/algolia/search/model/places/Country$Jordan;
+	public final fun getKazakhstan ()Lcom/algolia/search/model/places/Country$Kazakhstan;
+	public final fun getKenya ()Lcom/algolia/search/model/places/Country$Kenya;
+	public final fun getKiribati ()Lcom/algolia/search/model/places/Country$Kiribati;
+	public final fun getKuwait ()Lcom/algolia/search/model/places/Country$Kuwait;
+	public final fun getKyrgyzstan ()Lcom/algolia/search/model/places/Country$Kyrgyzstan;
+	public final fun getLaos ()Lcom/algolia/search/model/places/Country$Laos;
+	public final fun getLatvia ()Lcom/algolia/search/model/places/Country$Latvia;
+	public final fun getLebanon ()Lcom/algolia/search/model/places/Country$Lebanon;
+	public final fun getLesotho ()Lcom/algolia/search/model/places/Country$Lesotho;
+	public final fun getLiberia ()Lcom/algolia/search/model/places/Country$Liberia;
+	public final fun getLibya ()Lcom/algolia/search/model/places/Country$Libya;
+	public final fun getLiechtenstein ()Lcom/algolia/search/model/places/Country$Liechtenstein;
+	public final fun getLithuania ()Lcom/algolia/search/model/places/Country$Lithuania;
+	public final fun getLuxembourg ()Lcom/algolia/search/model/places/Country$Luxembourg;
+	public final fun getMacau ()Lcom/algolia/search/model/places/Country$Macau;
+	public final fun getMadagascar ()Lcom/algolia/search/model/places/Country$Madagascar;
+	public final fun getMalawi ()Lcom/algolia/search/model/places/Country$Malawi;
+	public final fun getMalaysia ()Lcom/algolia/search/model/places/Country$Malaysia;
+	public final fun getMaldives ()Lcom/algolia/search/model/places/Country$Maldives;
+	public final fun getMali ()Lcom/algolia/search/model/places/Country$Mali;
+	public final fun getMalta ()Lcom/algolia/search/model/places/Country$Malta;
+	public final fun getMarshallIslands ()Lcom/algolia/search/model/places/Country$MarshallIslands;
+	public final fun getMartinique ()Lcom/algolia/search/model/places/Country$Martinique;
+	public final fun getMauritania ()Lcom/algolia/search/model/places/Country$Mauritania;
+	public final fun getMauritius ()Lcom/algolia/search/model/places/Country$Mauritius;
+	public final fun getMayotte ()Lcom/algolia/search/model/places/Country$Mayotte;
+	public final fun getMexico ()Lcom/algolia/search/model/places/Country$Mexico;
+	public final fun getMicronesia ()Lcom/algolia/search/model/places/Country$Micronesia;
+	public final fun getMoldova ()Lcom/algolia/search/model/places/Country$Moldova;
+	public final fun getMonaco ()Lcom/algolia/search/model/places/Country$Monaco;
+	public final fun getMongolia ()Lcom/algolia/search/model/places/Country$Mongolia;
+	public final fun getMontenegro ()Lcom/algolia/search/model/places/Country$Montenegro;
+	public final fun getMontserrat ()Lcom/algolia/search/model/places/Country$Montserrat;
+	public final fun getMorocco ()Lcom/algolia/search/model/places/Country$Morocco;
+	public final fun getMozambique ()Lcom/algolia/search/model/places/Country$Mozambique;
+	public final fun getMyanmar ()Lcom/algolia/search/model/places/Country$Myanmar;
+	public final fun getNamibia ()Lcom/algolia/search/model/places/Country$Namibia;
+	public final fun getNauru ()Lcom/algolia/search/model/places/Country$Nauru;
+	public final fun getNepal ()Lcom/algolia/search/model/places/Country$Nepal;
+	public final fun getNetherlands ()Lcom/algolia/search/model/places/Country$Netherlands;
+	public final fun getNewCaledonia ()Lcom/algolia/search/model/places/Country$NewCaledonia;
+	public final fun getNewZealand ()Lcom/algolia/search/model/places/Country$NewZealand;
+	public final fun getNicaragua ()Lcom/algolia/search/model/places/Country$Nicaragua;
+	public final fun getNiger ()Lcom/algolia/search/model/places/Country$Niger;
+	public final fun getNigeria ()Lcom/algolia/search/model/places/Country$Nigeria;
+	public final fun getNiue ()Lcom/algolia/search/model/places/Country$Niue;
+	public final fun getNorfolkIsland ()Lcom/algolia/search/model/places/Country$NorfolkIsland;
+	public final fun getNorthKorea ()Lcom/algolia/search/model/places/Country$NorthKorea;
+	public final fun getNorthMacedonia ()Lcom/algolia/search/model/places/Country$NorthMacedonia;
+	public final fun getNorthernMarianaIslands ()Lcom/algolia/search/model/places/Country$NorthernMarianaIslands;
+	public final fun getNorway ()Lcom/algolia/search/model/places/Country$Norway;
+	public final fun getOman ()Lcom/algolia/search/model/places/Country$Oman;
+	public final fun getPakistan ()Lcom/algolia/search/model/places/Country$Pakistan;
+	public final fun getPalau ()Lcom/algolia/search/model/places/Country$Palau;
+	public final fun getPalestine ()Lcom/algolia/search/model/places/Country$Palestine;
+	public final fun getPanama ()Lcom/algolia/search/model/places/Country$Panama;
+	public final fun getPapuaNewGuinea ()Lcom/algolia/search/model/places/Country$PapuaNewGuinea;
+	public final fun getParaguay ()Lcom/algolia/search/model/places/Country$Paraguay;
+	public final fun getPeru ()Lcom/algolia/search/model/places/Country$Peru;
+	public final fun getPhilippines ()Lcom/algolia/search/model/places/Country$Philippines;
+	public final fun getPitcairnIslands ()Lcom/algolia/search/model/places/Country$PitcairnIslands;
+	public final fun getPoland ()Lcom/algolia/search/model/places/Country$Poland;
+	public final fun getPortugal ()Lcom/algolia/search/model/places/Country$Portugal;
+	public final fun getPuertoRico ()Lcom/algolia/search/model/places/Country$PuertoRico;
+	public final fun getQatar ()Lcom/algolia/search/model/places/Country$Qatar;
+	public final fun getRepublicOfTheCongo ()Lcom/algolia/search/model/places/Country$RepublicOfTheCongo;
+	public final fun getReunion ()Lcom/algolia/search/model/places/Country$Reunion;
+	public final fun getRomania ()Lcom/algolia/search/model/places/Country$Romania;
+	public final fun getRussia ()Lcom/algolia/search/model/places/Country$Russia;
+	public final fun getRwanda ()Lcom/algolia/search/model/places/Country$Rwanda;
+	public final fun getSaintBarthelemy ()Lcom/algolia/search/model/places/Country$SaintBarthelemy;
+	public final fun getSaintHelena ()Lcom/algolia/search/model/places/Country$SaintHelena;
+	public final fun getSaintKittsAndNevis ()Lcom/algolia/search/model/places/Country$SaintKittsAndNevis;
+	public final fun getSaintLucia ()Lcom/algolia/search/model/places/Country$SaintLucia;
+	public final fun getSaintMartin ()Lcom/algolia/search/model/places/Country$SaintMartin;
+	public final fun getSaintPierreAndMiquelon ()Lcom/algolia/search/model/places/Country$SaintPierreAndMiquelon;
+	public final fun getSaintVincentAndTheGrenadines ()Lcom/algolia/search/model/places/Country$SaintVincentAndTheGrenadines;
+	public final fun getSamoa ()Lcom/algolia/search/model/places/Country$Samoa;
+	public final fun getSanMarino ()Lcom/algolia/search/model/places/Country$SanMarino;
+	public final fun getSaoTomeAndPrincipe ()Lcom/algolia/search/model/places/Country$SaoTomeAndPrincipe;
+	public final fun getSaudiArabia ()Lcom/algolia/search/model/places/Country$SaudiArabia;
+	public final fun getSenegal ()Lcom/algolia/search/model/places/Country$Senegal;
+	public final fun getSerbia ()Lcom/algolia/search/model/places/Country$Serbia;
+	public final fun getSeychelles ()Lcom/algolia/search/model/places/Country$Seychelles;
+	public final fun getSierraLeone ()Lcom/algolia/search/model/places/Country$SierraLeone;
+	public final fun getSingapore ()Lcom/algolia/search/model/places/Country$Singapore;
+	public final fun getSintMaarten ()Lcom/algolia/search/model/places/Country$SintMaarten;
+	public final fun getSlovakia ()Lcom/algolia/search/model/places/Country$Slovakia;
+	public final fun getSlovenia ()Lcom/algolia/search/model/places/Country$Slovenia;
+	public final fun getSolomonIslands ()Lcom/algolia/search/model/places/Country$SolomonIslands;
+	public final fun getSomalia ()Lcom/algolia/search/model/places/Country$Somalia;
+	public final fun getSouthAfrica ()Lcom/algolia/search/model/places/Country$SouthAfrica;
+	public final fun getSouthGeorgiaAndTheSouthSandwichIslands ()Lcom/algolia/search/model/places/Country$SouthGeorgiaAndTheSouthSandwichIslands;
+	public final fun getSouthKorea ()Lcom/algolia/search/model/places/Country$SouthKorea;
+	public final fun getSouthSudan ()Lcom/algolia/search/model/places/Country$SouthSudan;
+	public final fun getSpain ()Lcom/algolia/search/model/places/Country$Spain;
+	public final fun getSriLanka ()Lcom/algolia/search/model/places/Country$SriLanka;
+	public final fun getSudan ()Lcom/algolia/search/model/places/Country$Sudan;
+	public final fun getSuriname ()Lcom/algolia/search/model/places/Country$Suriname;
+	public final fun getSvalbardAndJanMayen ()Lcom/algolia/search/model/places/Country$SvalbardAndJanMayen;
+	public final fun getSweden ()Lcom/algolia/search/model/places/Country$Sweden;
+	public final fun getSwitzerland ()Lcom/algolia/search/model/places/Country$Switzerland;
+	public final fun getSyria ()Lcom/algolia/search/model/places/Country$Syria;
+	public final fun getTaiwan ()Lcom/algolia/search/model/places/Country$Taiwan;
+	public final fun getTajikistan ()Lcom/algolia/search/model/places/Country$Tajikistan;
+	public final fun getTanzania ()Lcom/algolia/search/model/places/Country$Tanzania;
+	public final fun getThailand ()Lcom/algolia/search/model/places/Country$Thailand;
+	public final fun getTimorLeste ()Lcom/algolia/search/model/places/Country$TimorLeste;
+	public final fun getTogo ()Lcom/algolia/search/model/places/Country$Togo;
+	public final fun getTokelau ()Lcom/algolia/search/model/places/Country$Tokelau;
+	public final fun getTonga ()Lcom/algolia/search/model/places/Country$Tonga;
+	public final fun getTrinidadAndTobago ()Lcom/algolia/search/model/places/Country$TrinidadAndTobago;
+	public final fun getTunisia ()Lcom/algolia/search/model/places/Country$Tunisia;
+	public final fun getTurkey ()Lcom/algolia/search/model/places/Country$Turkey;
+	public final fun getTurkmenistan ()Lcom/algolia/search/model/places/Country$Turkmenistan;
+	public final fun getTurksAndCaicosIslands ()Lcom/algolia/search/model/places/Country$TurksAndCaicosIslands;
+	public final fun getTuvalu ()Lcom/algolia/search/model/places/Country$Tuvalu;
+	public final fun getUganda ()Lcom/algolia/search/model/places/Country$Uganda;
+	public final fun getUkraine ()Lcom/algolia/search/model/places/Country$Ukraine;
+	public final fun getUnitedArabEmirates ()Lcom/algolia/search/model/places/Country$UnitedArabEmirates;
+	public final fun getUnitedKingdom ()Lcom/algolia/search/model/places/Country$UnitedKingdom;
+	public final fun getUnitedStates ()Lcom/algolia/search/model/places/Country$UnitedStates;
+	public final fun getUnitedStatesMinorOutlyingIslands ()Lcom/algolia/search/model/places/Country$UnitedStatesMinorOutlyingIslands;
+	public final fun getUruguay ()Lcom/algolia/search/model/places/Country$Uruguay;
+	public final fun getUzbekistan ()Lcom/algolia/search/model/places/Country$Uzbekistan;
+	public final fun getVanuatu ()Lcom/algolia/search/model/places/Country$Vanuatu;
+	public final fun getVaticanCity ()Lcom/algolia/search/model/places/Country$VaticanCity;
+	public final fun getVenezuela ()Lcom/algolia/search/model/places/Country$Venezuela;
+	public final fun getVietnam ()Lcom/algolia/search/model/places/Country$Vietnam;
+	public final fun getVirginIslandsGB ()Lcom/algolia/search/model/places/Country$VirginIslandsGB;
+	public final fun getVirginIslandsUS ()Lcom/algolia/search/model/places/Country$VirginIslandsUS;
+	public final fun getWallisAndFutuna ()Lcom/algolia/search/model/places/Country$WallisAndFutuna;
+	public final fun getWesternSahara ()Lcom/algolia/search/model/places/Country$WesternSahara;
+	public final fun getYemen ()Lcom/algolia/search/model/places/Country$Yemen;
+	public final fun getZambia ()Lcom/algolia/search/model/places/Country$Zambia;
+	public final fun getZimbabwe ()Lcom/algolia/search/model/places/Country$Zimbabwe;
+	public final fun unaryPlus (Lcom/algolia/search/model/places/Country;)V
+}
+
+public final class com/algolia/search/dsl/places/DSLCountries$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/ranking/DSLCustomRanking {
+	public static final field Companion Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAsc ()Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+	public final fun getDesc ()Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+	public final fun invoke (Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/CustomRankingCriterion;
+	public final fun invoke (Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;Ljava/lang/String;)Lcom/algolia/search/model/settings/CustomRankingCriterion;
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/CustomRankingCriterion;)V
+}
+
+public final class com/algolia/search/dsl/ranking/DSLCustomRanking$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/ranking/DSLCustomRanking$Modifier : java/lang/Enum {
+	public static final field Asc Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+	public static final field Desc Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+	public static fun values ()[Lcom/algolia/search/dsl/ranking/DSLCustomRanking$Modifier;
+}
+
+public final class com/algolia/search/dsl/ranking/DSLIndexName {
+	public static final field Companion Lcom/algolia/search/dsl/ranking/DSLIndexName$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/IndexName;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/ranking/DSLIndexName$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/ranking/DSLRanking {
+	public static final field Companion Lcom/algolia/search/dsl/ranking/DSLRanking$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAsc ()Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+	public final fun getAttribute ()Lcom/algolia/search/model/settings/RankingCriterion$Attribute;
+	public final fun getCustom ()Lcom/algolia/search/model/settings/RankingCriterion$Custom;
+	public final fun getDesc ()Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+	public final fun getExact ()Lcom/algolia/search/model/settings/RankingCriterion$Exact;
+	public final fun getFilters ()Lcom/algolia/search/model/settings/RankingCriterion$Filters;
+	public final fun getGeo ()Lcom/algolia/search/model/settings/RankingCriterion$Geo;
+	public final fun getProximity ()Lcom/algolia/search/model/settings/RankingCriterion$Proximity;
+	public final fun getTypo ()Lcom/algolia/search/model/settings/RankingCriterion$Typo;
+	public final fun getWords ()Lcom/algolia/search/model/settings/RankingCriterion$Words;
+	public final fun invoke (Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/RankingCriterion;
+	public final fun invoke (Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;Ljava/lang/String;)Lcom/algolia/search/model/settings/RankingCriterion;
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/RankingCriterion;)V
+}
+
+public final class com/algolia/search/dsl/ranking/DSLRanking$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/ranking/DSLRanking$Modifier : java/lang/Enum {
+	public static final field Asc Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+	public static final field Desc Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+	public static fun values ()[Lcom/algolia/search/dsl/ranking/DSLRanking$Modifier;
+}
+
+public final class com/algolia/search/dsl/rule/DSLAutomaticFacetFilters {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLAutomaticFacetFilters$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun invoke (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public final fun invoke (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public static synthetic fun invoke$default (Lcom/algolia/search/dsl/rule/DSLAutomaticFacetFilters;Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public static synthetic fun invoke$default (Lcom/algolia/search/dsl/rule/DSLAutomaticFacetFilters;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public final fun unaryPlus (Lcom/algolia/search/model/Attribute;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/AutomaticFacetFilters;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLAutomaticFacetFilters$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLConditions {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLConditions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun Facet (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public final fun Facet (Ljava/lang/String;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public final fun Literal (Ljava/lang/String;)Lcom/algolia/search/model/rule/Pattern$Literal;
+	public final fun condition (Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;)Lcom/algolia/search/model/rule/Condition;
+	public static synthetic fun condition$default (Lcom/algolia/search/dsl/rule/DSLConditions;Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Condition;
+	public final fun getContains ()Lcom/algolia/search/model/rule/Anchoring$Contains;
+	public final fun getEndsWith ()Lcom/algolia/search/model/rule/Anchoring$EndsWith;
+	public final fun getIs ()Lcom/algolia/search/model/rule/Anchoring$Is;
+	public final fun getStartsWith ()Lcom/algolia/search/model/rule/Anchoring$StartsWith;
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/Condition;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLConditions$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLEdits {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLEdits$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun invoke (Ljava/lang/String;Ljava/lang/String;)Lcom/algolia/search/model/rule/Edit;
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/Edit;)V
+	public final fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLEdits$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLKt {
+	public static final fun rules (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLPromotions {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLPromotions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun invoke (Lcom/algolia/search/model/ObjectID;I)Lcom/algolia/search/model/rule/Promotion;
+	public final fun invoke (Ljava/lang/String;I)Lcom/algolia/search/model/rule/Promotion;
+	public final fun invoke (Ljava/util/List;I)Lcom/algolia/search/model/rule/Promotion;
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/Promotion;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLPromotions$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLRules {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLRules$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun Facet (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public final fun Facet (Ljava/lang/String;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public final fun automaticFacetFilters (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun conditions (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun consequence (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/model/rule/RenderingContent;)Lcom/algolia/search/model/rule/Consequence;
+	public static synthetic fun consequence$default (Lcom/algolia/search/dsl/rule/DSLRules;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/model/rule/RenderingContent;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Consequence;
+	public final fun edits (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun promotions (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun renderingContent (Lcom/algolia/search/model/rule/FacetOrdering;)Lcom/algolia/search/model/rule/RenderingContent;
+	public static synthetic fun renderingContent$default (Lcom/algolia/search/dsl/rule/DSLRules;Lcom/algolia/search/model/rule/FacetOrdering;ILjava/lang/Object;)Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun rule (Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;)V
+	public final fun rule (Ljava/lang/String;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;)V
+	public static synthetic fun rule$default (Lcom/algolia/search/dsl/rule/DSLRules;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun rule$default (Lcom/algolia/search/dsl/rule/DSLRules;Ljava/lang/String;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun timeRanges (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/Rule;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLRules$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/rule/DSLTimeRanges {
+	public static final field Companion Lcom/algolia/search/dsl/rule/DSLTimeRanges$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun unaryPlus (Lcom/algolia/search/model/rule/TimeRange;)V
+	public final fun unaryPlus (Lkotlin/ranges/LongRange;)V
+}
+
+public final class com/algolia/search/dsl/rule/DSLTimeRanges$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/strategy/DSLAdvancedSyntaxFeatures {
+	public static final field Companion Lcom/algolia/search/dsl/strategy/DSLAdvancedSyntaxFeatures$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExactPhrase ()Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$ExactPhrase;
+	public final fun getExcludeWords ()Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$ExcludeWords;
+	public final fun unaryPlus (Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures;)V
+}
+
+public final class com/algolia/search/dsl/strategy/DSLAdvancedSyntaxFeatures$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class com/algolia/search/dsl/strategy/DSLAlternativesAsExact {
+	public static final field Companion Lcom/algolia/search/dsl/strategy/DSLAlternativesAsExact$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIgnorePlurals ()Lcom/algolia/search/model/search/AlternativesAsExact$IgnorePlurals;
+	public final fun getMultiWordsSynonym ()Lcom/algolia/search/model/search/AlternativesAsExact$MultiWordsSynonym;
+	public final fun getSingleWordSynonym ()Lcom/algolia/search/model/search/AlternativesAsExact$SingleWordSynonym;
+	public final fun unaryPlus (Lcom/algolia/search/model/search/AlternativesAsExact;)V
+}
+
+public final class com/algolia/search/dsl/strategy/DSLAlternativesAsExact$Companion : com/algolia/search/dsl/DSL {
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointAPIKey {
+	public abstract fun addAPIKey (Lcom/algolia/search/model/apikey/APIKeyParams;Ljava/lang/String;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listAPIKeys (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restoreAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/apikey/APIKeyParams;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointAPIKey$DefaultImpls {
+	public static synthetic fun addAPIKey$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/model/apikey/APIKeyParams;Ljava/lang/String;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteAPIKey$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getAPIKey$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listAPIKeys$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun restoreAPIKey$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun updateAPIKey$default (Lcom/algolia/search/endpoint/EndpointAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/apikey/APIKeyParams;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointAdvanced {
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getLogs (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/LogType;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getTask (Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun wait (Lcom/algolia/search/model/task/Task;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun wait (Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitTask (Lcom/algolia/search/model/task/TaskID;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointAdvanced$DefaultImpls {
+	public static synthetic fun getLogs$default (Lcom/algolia/search/endpoint/EndpointAdvanced;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/LogType;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getTask$default (Lcom/algolia/search/endpoint/EndpointAdvanced;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun wait$default (Lcom/algolia/search/endpoint/EndpointAdvanced;Lcom/algolia/search/model/task/Task;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun wait$default (Lcom/algolia/search/endpoint/EndpointAdvanced;Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun waitTask$default (Lcom/algolia/search/endpoint/EndpointAdvanced;Lcom/algolia/search/model/task/TaskID;Ljava/lang/Long;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointAnalytics {
+	public abstract fun addABTest (Lcom/algolia/search/model/analytics/ABTest;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteABTest (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getABTest (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listABTests (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopABTest (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointAnalytics$DefaultImpls {
+	public static synthetic fun addABTest$default (Lcom/algolia/search/endpoint/EndpointAnalytics;Lcom/algolia/search/model/analytics/ABTest;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteABTest$default (Lcom/algolia/search/endpoint/EndpointAnalytics;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getABTest$default (Lcom/algolia/search/endpoint/EndpointAnalytics;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listABTests$default (Lcom/algolia/search/endpoint/EndpointAnalytics;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun stopABTest$default (Lcom/algolia/search/endpoint/EndpointAnalytics;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointAnswers {
+	public abstract fun findAnswers (Lcom/algolia/search/model/search/AnswersQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+}
+
+public final class com/algolia/search/endpoint/EndpointAnswers$DefaultImpls {
+	public static synthetic fun findAnswers$default (Lcom/algolia/search/endpoint/EndpointAnswers;Lcom/algolia/search/model/search/AnswersQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointDictionary {
+	public abstract fun clearDictionaryEntries (Lcom/algolia/search/model/dictionary/Dictionary;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteDictionaryEntries (Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getDictionarySettings (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceDictionaryEntries (Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveDictionaryEntries (Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchDictionaryEntries (Lcom/algolia/search/model/dictionary/Dictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setDictionarySettings (Lcom/algolia/search/model/dictionary/DictionarySettings;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointDictionary$DefaultImpls {
+	public static synthetic fun clearDictionaryEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/Dictionary;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteDictionaryEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getDictionarySettings$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceDictionaryEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveDictionaryEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/Dictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchDictionaryEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/Dictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun setDictionarySettings$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/dictionary/DictionarySettings;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointIndex {
+	public abstract fun copyIndex (Lcom/algolia/search/model/IndexName;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun copyRules (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun copySettings (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun copySynonyms (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteIndex (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun exists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun moveIndex (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointIndex$DefaultImpls {
+	public static synthetic fun copyIndex$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/model/IndexName;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun copyRules$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun copySettings$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun copySynonyms$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteIndex$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun moveIndex$default (Lcom/algolia/search/endpoint/EndpointIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointIndexing {
+	public abstract fun batch (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun clearObjects (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteObject (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteObjectsBy (Lcom/algolia/search/model/indexing/DeleteByQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getObject (Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getObject (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getObjects (Ljava/util/List;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun partialUpdateObject (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/indexing/Partial;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun partialUpdateObjects (Ljava/util/List;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllObjects (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllObjects (Lkotlinx/serialization/KSerializer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceObject (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceObject (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceObjects (Lkotlinx/serialization/KSerializer;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveObject (Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveObject (Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveObjects (Lkotlinx/serialization/KSerializer;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointIndexing$DefaultImpls {
+	public static synthetic fun batch$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun clearObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteObjectsBy$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/model/indexing/DeleteByQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun partialUpdateObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/indexing/Partial;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun partialUpdateObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/KSerializer;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveObject$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveObjects$default (Lcom/algolia/search/endpoint/EndpointIndexing;Lkotlinx/serialization/KSerializer;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointInsights {
+	public abstract fun sendEvent (Lcom/algolia/search/model/insights/InsightsEvent;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendEvents (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointInsights$DefaultImpls {
+	public static synthetic fun sendEvent$default (Lcom/algolia/search/endpoint/EndpointInsights;Lcom/algolia/search/model/insights/InsightsEvent;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun sendEvents$default (Lcom/algolia/search/endpoint/EndpointInsights;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointInsightsUser {
+	public abstract fun clickedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun clickedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun clickedObjectIDsAfterSearch (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun convertedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun convertedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun convertedObjectIDsAfterSearch (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun viewedFilters (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun viewedObjectIDs (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointInsightsUser$DefaultImpls {
+	public static synthetic fun clickedFilters$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun clickedObjectIDs$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun clickedObjectIDsAfterSearch$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun convertedFilters$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun convertedObjectIDs$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun convertedObjectIDsAfterSearch$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/QueryID;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun viewedFilters$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun viewedObjectIDs$default (Lcom/algolia/search/endpoint/EndpointInsightsUser;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/EventName;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointMultiCluster {
+	public abstract fun assignUserID (Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun assignUserIds (Ljava/util/List;Lcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getTopUserID (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getUserID (Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun hasPendingMapping (ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listClusters (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listUserIDs (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeUserID (Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchUserID (Lcom/algolia/search/model/multicluster/UserIDQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointMultiCluster$DefaultImpls {
+	public static synthetic fun assignUserID$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun assignUserIds$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Ljava/util/List;Lcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getTopUserID$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getUserID$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun hasPendingMapping$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listClusters$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listUserIDs$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun removeUserID$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/model/multicluster/UserID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchUserID$default (Lcom/algolia/search/endpoint/EndpointMultiCluster;Lcom/algolia/search/model/multicluster/UserIDQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointMultipleIndex {
+	public abstract fun listIndexAPIKeys (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listIndices (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun multipleBatchObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun multipleGetObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun multipleQueries (Ljava/util/List;Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun search (Ljava/util/List;Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointMultipleIndex$DefaultImpls {
+	public static synthetic fun listIndexAPIKeys$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listIndices$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun multipleBatchObjects$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun multipleGetObjects$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun multipleQueries$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Ljava/util/List;Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun search$default (Lcom/algolia/search/endpoint/EndpointMultipleIndex;Ljava/util/List;Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointPersonalization {
+	public abstract fun deletePersonalizationProfile (Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getPersonalizationProfile (Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getPersonalizationStrategy (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setPersonalizationStrategy (Lcom/algolia/search/model/personalization/PersonalizationStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointPersonalization$DefaultImpls {
+	public static synthetic fun deletePersonalizationProfile$default (Lcom/algolia/search/endpoint/EndpointPersonalization;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPersonalizationProfile$default (Lcom/algolia/search/endpoint/EndpointPersonalization;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPersonalizationStrategy$default (Lcom/algolia/search/endpoint/EndpointPersonalization;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun setPersonalizationStrategy$default (Lcom/algolia/search/endpoint/EndpointPersonalization;Lcom/algolia/search/model/personalization/PersonalizationStrategy;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointPlaces {
+	public abstract fun getByObjectID (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun reverseGeocoding (Lcom/algolia/search/model/search/Language;Lcom/algolia/search/model/search/Point;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun reverseGeocoding (Lcom/algolia/search/model/search/Point;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchPlaces (Lcom/algolia/search/model/places/PlacesQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchPlaces (Lcom/algolia/search/model/search/Language;Lcom/algolia/search/model/places/PlacesQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointPlaces$DefaultImpls {
+	public static synthetic fun getByObjectID$default (Lcom/algolia/search/endpoint/EndpointPlaces;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun reverseGeocoding$default (Lcom/algolia/search/endpoint/EndpointPlaces;Lcom/algolia/search/model/search/Language;Lcom/algolia/search/model/search/Point;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun reverseGeocoding$default (Lcom/algolia/search/endpoint/EndpointPlaces;Lcom/algolia/search/model/search/Point;Ljava/lang/Integer;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchPlaces$default (Lcom/algolia/search/endpoint/EndpointPlaces;Lcom/algolia/search/model/places/PlacesQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchPlaces$default (Lcom/algolia/search/endpoint/EndpointPlaces;Lcom/algolia/search/model/search/Language;Lcom/algolia/search/model/places/PlacesQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointRecommend {
+	public abstract fun getFrequentlyBoughtTogether (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRecommendations (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRelatedProducts (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointRecommend$DefaultImpls {
+	public static synthetic fun getFrequentlyBoughtTogether$default (Lcom/algolia/search/endpoint/EndpointRecommend;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendations$default (Lcom/algolia/search/endpoint/EndpointRecommend;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRelatedProducts$default (Lcom/algolia/search/endpoint/EndpointRecommend;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointRule {
+	public abstract fun clearRules (Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteRule (Lcom/algolia/search/model/ObjectID;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getRule (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllRules (Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveRule (Lcom/algolia/search/model/rule/Rule;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveRules (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchRules (Lcom/algolia/search/model/rule/RuleQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointRule$DefaultImpls {
+	public static synthetic fun clearRules$default (Lcom/algolia/search/endpoint/EndpointRule;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteRule$default (Lcom/algolia/search/endpoint/EndpointRule;Lcom/algolia/search/model/ObjectID;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRule$default (Lcom/algolia/search/endpoint/EndpointRule;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceAllRules$default (Lcom/algolia/search/endpoint/EndpointRule;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveRule$default (Lcom/algolia/search/endpoint/EndpointRule;Lcom/algolia/search/model/rule/Rule;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveRules$default (Lcom/algolia/search/endpoint/EndpointRule;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchRules$default (Lcom/algolia/search/endpoint/EndpointRule;Lcom/algolia/search/model/rule/RuleQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointSearch {
+	public abstract fun advancedSearch (Lcom/algolia/search/model/search/Query;Ljava/util/Set;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun browse (Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun browse (Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun findObject (Lkotlin/jvm/functions/Function1;Lcom/algolia/search/model/search/Query;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun search (Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchForFacets (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointSearch$DefaultImpls {
+	public static synthetic fun advancedSearch$default (Lcom/algolia/search/endpoint/EndpointSearch;Lcom/algolia/search/model/search/Query;Ljava/util/Set;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun browse$default (Lcom/algolia/search/endpoint/EndpointSearch;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun browse$default (Lcom/algolia/search/endpoint/EndpointSearch;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun findObject$default (Lcom/algolia/search/endpoint/EndpointSearch;Lkotlin/jvm/functions/Function1;Lcom/algolia/search/model/search/Query;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun search$default (Lcom/algolia/search/endpoint/EndpointSearch;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchForFacets$default (Lcom/algolia/search/endpoint/EndpointSearch;Lcom/algolia/search/model/Attribute;Ljava/lang/String;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointSettings {
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getSettings (Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setSettings (Lcom/algolia/search/model/settings/Settings;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointSettings$DefaultImpls {
+	public static synthetic fun getSettings$default (Lcom/algolia/search/endpoint/EndpointSettings;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun setSettings$default (Lcom/algolia/search/endpoint/EndpointSettings;Lcom/algolia/search/model/settings/Settings;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/algolia/search/endpoint/EndpointSynonym {
+	public abstract fun clearSynonyms (Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteSynonym (Lcom/algolia/search/model/ObjectID;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getSynonym (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllSynonyms (Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveSynonym (Lcom/algolia/search/model/synonym/Synonym;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun saveSynonyms (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchSynonyms (Lcom/algolia/search/model/synonym/SynonymQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/EndpointSynonym$DefaultImpls {
+	public static synthetic fun clearSynonyms$default (Lcom/algolia/search/endpoint/EndpointSynonym;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteSynonym$default (Lcom/algolia/search/endpoint/EndpointSynonym;Lcom/algolia/search/model/ObjectID;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getSynonym$default (Lcom/algolia/search/endpoint/EndpointSynonym;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun replaceAllSynonyms$default (Lcom/algolia/search/endpoint/EndpointSynonym;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveSynonym$default (Lcom/algolia/search/endpoint/EndpointSynonym;Lcom/algolia/search/model/synonym/Synonym;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun saveSynonyms$default (Lcom/algolia/search/endpoint/EndpointSynonym;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchSynonyms$default (Lcom/algolia/search/endpoint/EndpointSynonym;Lcom/algolia/search/model/synonym/SynonymQuery;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/endpoint/extension/EndpointDictionaryKt {
+	public static final fun deleteCompoundEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteCompoundEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun deletePluralEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePluralEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun deleteStopwordEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteStopwordEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun replaceCompoundEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun replaceCompoundEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun replacePluralEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun replacePluralEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun replaceStopwordEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun replaceStopwordEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun saveCompoundEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun saveCompoundEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun savePluralEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun savePluralEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun saveStopwordEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun saveStopwordEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun searchCompoundEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchCompoundEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun searchPluralEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchPluralEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun searchStopwordEntries (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchStopwordEntries$default (Lcom/algolia/search/endpoint/EndpointDictionary;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/algolia/search/exception/AlgoliaRuntimeException : java/lang/RuntimeException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/algolia/search/exception/EmptyListException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/exception/EmptyStringException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/algolia/search/exception/UnreachableHostsException : com/algolia/search/exception/AlgoliaRuntimeException {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Ljava/lang/Throwable;)V
+	public final fun getExceptions ()Ljava/util/List;
+}
+
+public final class com/algolia/search/helper/ConstructorKt {
+	public static final fun and (FF)Lcom/algolia/search/model/search/Point;
+	public static final fun toABTestID (J)Lcom/algolia/search/model/analytics/ABTestID;
+	public static final fun toAPIKey (Ljava/lang/String;)Lcom/algolia/search/model/APIKey;
+	public static final fun toApplicationID (Ljava/lang/String;)Lcom/algolia/search/model/ApplicationID;
+	public static final fun toAttribute (Ljava/lang/String;)Lcom/algolia/search/model/Attribute;
+	public static final fun toClusterName (Ljava/lang/String;)Lcom/algolia/search/model/multicluster/ClusterName;
+	public static final fun toCursor (Ljava/lang/String;)Lcom/algolia/search/model/search/Cursor;
+	public static final fun toDictionaryTaskID (J)Lcom/algolia/search/model/task/DictionaryTaskID;
+	public static final fun toEventName (Ljava/lang/String;)Lcom/algolia/search/model/insights/EventName;
+	public static final fun toIndexName (Ljava/lang/String;)Lcom/algolia/search/model/IndexName;
+	public static final fun toObjectID (Ljava/lang/String;)Lcom/algolia/search/model/ObjectID;
+	public static final fun toQueryID (Ljava/lang/String;)Lcom/algolia/search/model/QueryID;
+	public static final fun toTaskID (J)Lcom/algolia/search/model/task/TaskID;
+	public static final fun toUserID (Ljava/lang/String;)Lcom/algolia/search/model/multicluster/UserID;
+	public static final fun toUserToken (Ljava/lang/String;)Lcom/algolia/search/model/insights/UserToken;
+}
+
+public final class com/algolia/search/helper/ResponseExceptionKt {
+	public static final fun readContent (Lio/ktor/client/features/ResponseException;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/helper/ResponseSearchKt {
+	public static final fun deserialize (Ljava/util/List;Lkotlinx/serialization/DeserializationStrategy;)Ljava/util/List;
+}
+
+public final class com/algolia/search/model/APIKey : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/APIKey$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/APIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/APIKey;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/APIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/APIKey$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/APIKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/APIKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/ApplicationID : com/algolia/search/model/internal/Raw {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/ApplicationID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/ApplicationID;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/ApplicationID;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/Attribute : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/Attribute$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/Attribute;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/Attribute;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/Attribute;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/Attribute$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/Attribute;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/Attribute;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/ClientDate : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/ClientDate$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/ClientDate;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/ClientDate;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/ClientDate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/util/Date;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/ClientDate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/IndexName : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/IndexName$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/IndexName;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/IndexName;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/IndexName;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/IndexName$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/IndexName;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/IndexName;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/LogType : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/LogType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/LogType$All : com/algolia/search/model/LogType {
+	public static final field INSTANCE Lcom/algolia/search/model/LogType$All;
+}
+
+public final class com/algolia/search/model/LogType$Build : com/algolia/search/model/LogType {
+	public static final field INSTANCE Lcom/algolia/search/model/LogType$Build;
+}
+
+public final class com/algolia/search/model/LogType$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/LogType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/LogType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/LogType$Error : com/algolia/search/model/LogType {
+	public static final field INSTANCE Lcom/algolia/search/model/LogType$Error;
+}
+
+public final class com/algolia/search/model/LogType$Other : com/algolia/search/model/LogType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/LogType$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/LogType$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/LogType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/LogType$Query : com/algolia/search/model/LogType {
+	public static final field INSTANCE Lcom/algolia/search/model/LogType$Query;
+}
+
+public final class com/algolia/search/model/ObjectID : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/ObjectID$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/ObjectID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/ObjectID;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/ObjectID;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/ObjectID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/ObjectID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/ObjectID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/QueryID : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/QueryID$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/QueryID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/QueryID;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/QueryID;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/QueryID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/QueryID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/QueryID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/analytics/ABTest {
+	public static final field Companion Lcom/algolia/search/model/analytics/ABTest$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component3 ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun component4 ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;)Lcom/algolia/search/model/analytics/ABTest;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/analytics/ABTest;Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;ILjava/lang/Object;)Lcom/algolia/search/model/analytics/ABTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVariantA ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun getVariantB ()Lcom/algolia/search/model/analytics/Variant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/analytics/ABTest$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/analytics/ABTest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/analytics/ABTest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/analytics/ABTestID : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/analytics/ABTestID$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/algolia/search/model/analytics/ABTestID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/analytics/ABTestID;JILjava/lang/Object;)Lcom/algolia/search/model/analytics/ABTestID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Ljava/lang/Long;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/analytics/ABTestID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/analytics/ABTestID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/analytics/ABTestID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/analytics/ABTestStatus : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/analytics/ABTestStatus$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Active : com/algolia/search/model/analytics/ABTestStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/analytics/ABTestStatus$Active;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/analytics/ABTestStatus;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/analytics/ABTestStatus;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Expired : com/algolia/search/model/analytics/ABTestStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/analytics/ABTestStatus$Expired;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Failed : com/algolia/search/model/analytics/ABTestStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/analytics/ABTestStatus$Failed;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Other : com/algolia/search/model/analytics/ABTestStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/analytics/ABTestStatus$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/analytics/ABTestStatus$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/analytics/ABTestStatus$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/analytics/ABTestStatus$Stopped : com/algolia/search/model/analytics/ABTestStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/analytics/ABTestStatus$Stopped;
+}
+
+public final class com/algolia/search/model/analytics/Variant {
+	public static final field Companion Lcom/algolia/search/model/analytics/Variant$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;ILcom/algolia/search/model/search/Query;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;ILcom/algolia/search/model/search/Query;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;ILcom/algolia/search/model/search/Query;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()I
+	public final fun component3 ()Lcom/algolia/search/model/search/Query;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lcom/algolia/search/model/IndexName;ILcom/algolia/search/model/search/Query;Ljava/lang/String;)Lcom/algolia/search/model/analytics/Variant;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/IndexName;ILcom/algolia/search/model/search/Query;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/analytics/Variant;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomSearchParameters ()Lcom/algolia/search/model/search/Query;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getTrafficPercentage ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/analytics/Variant;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/analytics/Variant$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/analytics/Variant$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/analytics/Variant;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/analytics/Variant;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/analytics/Variant$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/apikey/ACL : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/apikey/ACL$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/apikey/ACL$AddObject : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$AddObject;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Analytics : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$Analytics;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Browse : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$Browse;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/apikey/ACL;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/apikey/ACL;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/apikey/ACL$DeleteIndex : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$DeleteIndex;
+}
+
+public final class com/algolia/search/model/apikey/ACL$DeleteObject : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$DeleteObject;
+}
+
+public final class com/algolia/search/model/apikey/ACL$EditSettings : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$EditSettings;
+}
+
+public final class com/algolia/search/model/apikey/ACL$ListIndices : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$ListIndices;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Logs : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$Logs;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Other : com/algolia/search/model/apikey/ACL {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/apikey/ACL$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/apikey/ACL$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/apikey/ACL$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Search : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$Search;
+}
+
+public final class com/algolia/search/model/apikey/ACL$SeeUnretrievableAttributes : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$SeeUnretrievableAttributes;
+}
+
+public final class com/algolia/search/model/apikey/ACL$Settings : com/algolia/search/model/apikey/ACL {
+	public static final field INSTANCE Lcom/algolia/search/model/apikey/ACL$Settings;
+}
+
+public final class com/algolia/search/model/apikey/APIKeyKt {
+	public static final fun generateSecuredAPIKey (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;)Lcom/algolia/search/model/APIKey;
+	public static final fun getSecuredApiKeyRemainingValidity (Lcom/algolia/search/model/APIKey;)J
+}
+
+public final class com/algolia/search/model/apikey/APIKeyParams {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lcom/algolia/search/model/search/Query;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/lang/String;)Lcom/algolia/search/model/apikey/APIKeyParams;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/apikey/APIKeyParams;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/apikey/APIKeyParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getACLs ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIndices ()Ljava/util/List;
+	public final fun getMaxHitsPerQuery ()Ljava/lang/Integer;
+	public final fun getMaxQueriesPerIPPerHour ()Ljava/lang/Integer;
+	public final fun getQuery ()Lcom/algolia/search/model/search/Query;
+	public final fun getReferers ()Ljava/util/List;
+	public final fun getValidity ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/apikey/SecuredAPIKeyRestriction {
+	public static final field Companion Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Query;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun copy (Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;)Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;ILjava/lang/Object;)Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQuery ()Lcom/algolia/search/model/search/Query;
+	public final fun getRestrictIndices ()Ljava/util/List;
+	public final fun getRestrictSources ()Ljava/util/List;
+	public final fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun getValidUntil ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/apikey/SecuredAPIKeyRestriction$Companion {
+	public final fun invoke (Lcom/algolia/search/model/search/Query;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;)Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;
+	public static synthetic fun invoke$default (Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction$Companion;Lcom/algolia/search/model/search/Query;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/algolia/search/model/insights/UserToken;ILjava/lang/Object;)Lcom/algolia/search/model/apikey/SecuredAPIKeyRestriction;
+}
+
+public abstract class com/algolia/search/model/dictionary/Dictionary : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/dictionary/Dictionary$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/Dictionary;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlinx/serialization/KSerializer;)V
+}
+
+public final class com/algolia/search/model/dictionary/Dictionary$Companion {
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/Dictionary$Compounds : com/algolia/search/model/dictionary/Dictionary {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/Dictionary$Compounds;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/Dictionary$Plurals : com/algolia/search/model/dictionary/Dictionary {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/Dictionary$Plurals;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/Dictionary$Stopwords : com/algolia/search/model/dictionary/Dictionary {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/Dictionary$Stopwords;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/dictionary/DictionaryEntry {
+	public abstract fun getLanguage ()Lcom/algolia/search/model/search/Language;
+	public abstract fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Compound : com/algolia/search/model/dictionary/DictionaryEntry {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lcom/algolia/search/model/search/Language;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Ljava/util/List;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDecomposition ()Ljava/util/List;
+	public fun getLanguage ()Lcom/algolia/search/model/search/Language;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getWord ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Compound$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DictionaryEntry$Compound;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Compound$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Plural : com/algolia/search/model/dictionary/DictionaryEntry {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lcom/algolia/search/model/search/Language;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/util/List;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLanguage ()Lcom/algolia/search/model/search/Language;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getWords ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Plural$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DictionaryEntry$Plural;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Plural$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$State : java/lang/Enum {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DictionaryEntry$State$Companion;
+	public static final field Disabled Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public static final field Enabled Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public static fun values ()[Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$State$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DictionaryEntry$State$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$State$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Stopword : com/algolia/search/model/dictionary/DictionaryEntry {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lcom/algolia/search/model/search/Language;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/search/Language;Ljava/lang/String;Lcom/algolia/search/model/dictionary/DictionaryEntry$State;ILjava/lang/Object;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLanguage ()Lcom/algolia/search/model/search/Language;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getState ()Lcom/algolia/search/model/dictionary/DictionaryEntry$State;
+	public final fun getWord ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Stopword$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DictionaryEntry$Stopword;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionaryEntry$Stopword$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionarySettings {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DictionarySettings$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILcom/algolia/search/model/dictionary/DisableStandardEntries;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/dictionary/DisableStandardEntries;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/dictionary/DisableStandardEntries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/dictionary/DisableStandardEntries;
+	public final fun copy (Lcom/algolia/search/model/dictionary/DisableStandardEntries;)Lcom/algolia/search/model/dictionary/DictionarySettings;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/dictionary/DictionarySettings;Lcom/algolia/search/model/dictionary/DisableStandardEntries;ILjava/lang/Object;)Lcom/algolia/search/model/dictionary/DictionarySettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisableStandardEntries ()Lcom/algolia/search/model/dictionary/DisableStandardEntries;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/DictionarySettings;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/dictionary/DictionarySettings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DictionarySettings$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DictionarySettings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DictionarySettings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DictionarySettings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DisableStandardEntries {
+	public static final field Companion Lcom/algolia/search/model/dictionary/DisableStandardEntries$Companion;
+	public synthetic fun <init> (ILjava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/algolia/search/model/dictionary/DisableStandardEntries;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/dictionary/DisableStandardEntries;Ljava/util/Map;ILjava/lang/Object;)Lcom/algolia/search/model/dictionary/DisableStandardEntries;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStopwords ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/dictionary/DisableStandardEntries;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/dictionary/DisableStandardEntries$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/dictionary/DisableStandardEntries$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/dictionary/DisableStandardEntries;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/dictionary/DisableStandardEntries;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/dictionary/DisableStandardEntries$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/filter/Filter {
+	public abstract fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public abstract fun isNegated ()Z
+}
+
+public final class com/algolia/search/model/filter/Filter$Facet : com/algolia/search/model/filter/Filter {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;Ljava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;Ljava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;ZLjava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/algolia/search/model/filter/Filter$Facet$Value;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/algolia/search/model/Attribute;ZLcom/algolia/search/model/filter/Filter$Facet$Value;Ljava/lang/Integer;)Lcom/algolia/search/model/filter/Filter$Facet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Facet;Lcom/algolia/search/model/Attribute;ZLcom/algolia/search/model/filter/Filter$Facet$Value;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getScore ()Ljava/lang/Integer;
+	public final fun getValue ()Lcom/algolia/search/model/filter/Filter$Facet$Value;
+	public fun hashCode ()I
+	public fun isNegated ()Z
+	public final fun not ()Lcom/algolia/search/model/filter/Filter$Facet;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/filter/Filter$Facet$Value {
+	public abstract fun getRaw ()Ljava/lang/Object;
+}
+
+public final class com/algolia/search/model/filter/Filter$Facet$Value$Boolean : com/algolia/search/model/filter/Filter$Facet$Value {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/algolia/search/model/filter/Filter$Facet$Value$Boolean;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Facet$Value$Boolean;ZILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Facet$Value$Boolean;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Ljava/lang/Boolean;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/Filter$Facet$Value$Number : com/algolia/search/model/filter/Filter$Facet$Value {
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;)Lcom/algolia/search/model/filter/Filter$Facet$Value$Number;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Facet$Value$Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Facet$Value$Number;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Ljava/lang/Number;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/Filter$Facet$Value$String : com/algolia/search/model/filter/Filter$Facet$Value {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/filter/Filter$Facet$Value$String;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Facet$Value$String;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Facet$Value$String;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/Filter$Numeric : com/algolia/search/model/filter/Filter {
+	public fun <init> (Lcom/algolia/search/model/Attribute;DDZ)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;DDZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;FFZ)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;FFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/IntRange;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Lkotlin/ranges/LongRange;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;ZLcom/algolia/search/model/filter/Filter$Numeric$Value;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/algolia/search/model/filter/Filter$Numeric$Value;
+	public final fun copy (Lcom/algolia/search/model/Attribute;ZLcom/algolia/search/model/filter/Filter$Numeric$Value;)Lcom/algolia/search/model/filter/Filter$Numeric;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Numeric;Lcom/algolia/search/model/Attribute;ZLcom/algolia/search/model/filter/Filter$Numeric$Value;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Numeric;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getValue ()Lcom/algolia/search/model/filter/Filter$Numeric$Value;
+	public fun hashCode ()I
+	public fun isNegated ()Z
+	public final fun not ()Lcom/algolia/search/model/filter/Filter$Numeric;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/filter/Filter$Numeric$Value {
+}
+
+public final class com/algolia/search/model/filter/Filter$Numeric$Value$Comparison : com/algolia/search/model/filter/Filter$Numeric$Value {
+	public fun <init> (Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;)V
+	public final fun component1 ()Lcom/algolia/search/model/filter/NumericOperator;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;)Lcom/algolia/search/model/filter/Filter$Numeric$Value$Comparison;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Numeric$Value$Comparison;Lcom/algolia/search/model/filter/NumericOperator;Ljava/lang/Number;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Numeric$Value$Comparison;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumber ()Ljava/lang/Number;
+	public final fun getOperator ()Lcom/algolia/search/model/filter/NumericOperator;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/Filter$Numeric$Value$Range : com/algolia/search/model/filter/Filter$Numeric$Value {
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/algolia/search/model/filter/Filter$Numeric$Value$Range;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Numeric$Value$Range;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Numeric$Value$Range;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLowerBound ()Ljava/lang/Number;
+	public final fun getUpperBound ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/Filter$Tag : com/algolia/search/model/filter/Filter {
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/algolia/search/model/Attribute;ZLjava/lang/String;)Lcom/algolia/search/model/filter/Filter$Tag;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/Filter$Tag;Lcom/algolia/search/model/Attribute;ZLjava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/Filter$Tag;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isNegated ()Z
+	public final fun not ()Lcom/algolia/search/model/filter/Filter$Tag;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/filter/FilterConverter : kotlin/jvm/functions/Function1 {
+}
+
+public final class com/algolia/search/model/filter/FilterConverter$Legacy : com/algolia/search/model/filter/FilterConverter {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterConverter$Legacy;
+	public fun invoke (Lcom/algolia/search/model/filter/Filter;)Ljava/util/List;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/model/filter/FilterConverter$Legacy$Unquoted : com/algolia/search/model/filter/FilterConverter {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterConverter$Legacy$Unquoted;
+	public fun invoke (Lcom/algolia/search/model/filter/Filter;)Ljava/util/List;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/algolia/search/model/filter/FilterConverter$SQL : com/algolia/search/model/filter/FilterConverter {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterConverter$SQL;
+	public fun invoke (Lcom/algolia/search/model/filter/Filter;)Ljava/lang/String;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/algolia/search/model/filter/FilterGroup : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun add (Lcom/algolia/search/model/filter/Filter;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public abstract fun contains (Lcom/algolia/search/model/filter/Filter;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	protected abstract fun getFilters ()Ljava/util/Set;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getSize ()I
+	public fun iterator ()Ljava/util/Iterator;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun retainAll (Ljava/util/Collection;)Z
+	public final fun size ()I
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+}
+
+public abstract class com/algolia/search/model/filter/FilterGroup$And : com/algolia/search/model/filter/FilterGroup, java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contains (Lcom/algolia/search/model/filter/Filter;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	protected fun getFilters ()Ljava/util/Set;
+	public fun getName ()Ljava/lang/String;
+	public fun getSize ()I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$And$Any : com/algolia/search/model/filter/FilterGroup$And {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$And$Any;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$And$Any;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$And$Any;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$And$Facet : com/algolia/search/model/filter/FilterGroup$And {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Facet;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Facet;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$And$Facet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$And$Facet;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$And$Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$And$Hierarchical : com/algolia/search/model/filter/FilterGroup$And {
+	public fun <init> (Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$And$Hierarchical;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$And$Hierarchical;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$And$Hierarchical;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
+	public final fun getPath ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$And$Numeric : com/algolia/search/model/filter/FilterGroup$And {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Numeric;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Numeric;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$And$Numeric;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$And$Numeric;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$And$Numeric;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$And$Tag : com/algolia/search/model/filter/FilterGroup$And {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Tag;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Tag;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$And$Tag;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$And$Tag;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$And$Tag;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/filter/FilterGroup$Or : com/algolia/search/model/filter/FilterGroup, java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contains (Lcom/algolia/search/model/filter/Filter;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	protected fun getFilters ()Ljava/util/Set;
+	public fun getName ()Ljava/lang/String;
+	public fun getSize ()I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$Or$Facet : com/algolia/search/model/filter/FilterGroup$Or {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Facet;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Facet;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$Or$Facet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$Or$Facet;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$Or$Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$Or$Numeric : com/algolia/search/model/filter/FilterGroup$Or {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Numeric;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Numeric;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$Or$Numeric;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$Or$Numeric;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$Or$Numeric;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroup$Or$Tag : com/algolia/search/model/filter/FilterGroup$Or {
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lcom/algolia/search/model/filter/Filter$Tag;Ljava/lang/String;)V
+	public synthetic fun <init> ([Lcom/algolia/search/model/filter/Filter$Tag;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;)Lcom/algolia/search/model/filter/FilterGroup$Or$Tag;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/filter/FilterGroup$Or$Tag;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/filter/FilterGroup$Or$Tag;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/filter/FilterGroupsConverter : kotlin/jvm/functions/Function1 {
+}
+
+public abstract class com/algolia/search/model/filter/FilterGroupsConverter$Legacy : com/algolia/search/model/filter/FilterGroupsConverter {
+	public final fun Unquoted (Ljava/util/Set;)Ljava/util/List;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Ljava/util/Set;)Ljava/util/List;
+}
+
+public final class com/algolia/search/model/filter/FilterGroupsConverter$Legacy$Facet : com/algolia/search/model/filter/FilterGroupsConverter$Legacy {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterGroupsConverter$Legacy$Facet;
+}
+
+public final class com/algolia/search/model/filter/FilterGroupsConverter$Legacy$Numeric : com/algolia/search/model/filter/FilterGroupsConverter$Legacy {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterGroupsConverter$Legacy$Numeric;
+}
+
+public final class com/algolia/search/model/filter/FilterGroupsConverter$Legacy$Tag : com/algolia/search/model/filter/FilterGroupsConverter$Legacy {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterGroupsConverter$Legacy$Tag;
+}
+
+public final class com/algolia/search/model/filter/FilterGroupsConverter$SQL : com/algolia/search/model/filter/FilterGroupsConverter {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterGroupsConverter$SQL;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Ljava/util/Set;)Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/FilterGroupsConverter$SQL$Unquoted : com/algolia/search/model/filter/FilterGroupsConverter {
+	public static final field INSTANCE Lcom/algolia/search/model/filter/FilterGroupsConverter$SQL$Unquoted;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Ljava/util/Set;)Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/filter/NumericOperator : java/lang/Enum {
+	public static final field Equals Lcom/algolia/search/model/filter/NumericOperator;
+	public static final field Greater Lcom/algolia/search/model/filter/NumericOperator;
+	public static final field GreaterOrEquals Lcom/algolia/search/model/filter/NumericOperator;
+	public static final field Less Lcom/algolia/search/model/filter/NumericOperator;
+	public static final field LessOrEquals Lcom/algolia/search/model/filter/NumericOperator;
+	public static final field NotEquals Lcom/algolia/search/model/filter/NumericOperator;
+	public final fun getRaw ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/model/filter/NumericOperator;
+	public static fun values ()[Lcom/algolia/search/model/filter/NumericOperator;
+}
+
+public abstract class com/algolia/search/model/index/Scope : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/index/Scope$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/index/Scope$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/index/Scope;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/index/Scope;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/index/Scope$Other : com/algolia/search/model/index/Scope {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/index/Scope$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/index/Scope$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/index/Scope$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/index/Scope$Rules : com/algolia/search/model/index/Scope {
+	public static final field INSTANCE Lcom/algolia/search/model/index/Scope$Rules;
+}
+
+public final class com/algolia/search/model/index/Scope$Settings : com/algolia/search/model/index/Scope {
+	public static final field INSTANCE Lcom/algolia/search/model/index/Scope$Settings;
+}
+
+public final class com/algolia/search/model/index/Scope$Synonyms : com/algolia/search/model/index/Scope {
+	public static final field INSTANCE Lcom/algolia/search/model/index/Scope$Synonyms;
+}
+
+public abstract class com/algolia/search/model/indexing/BatchOperation : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/indexing/BatchOperation$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$AddObject : com/algolia/search/model/indexing/BatchOperation {
+	public static final field Companion Lcom/algolia/search/model/indexing/BatchOperation$AddObject$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/indexing/BatchOperation$AddObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/BatchOperation$AddObject;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$AddObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$AddObject$Companion {
+	public final fun from (Lkotlinx/serialization/KSerializer;Ljava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$AddObject;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$ClearIndex : com/algolia/search/model/indexing/BatchOperation {
+	public static final field INSTANCE Lcom/algolia/search/model/indexing/BatchOperation$ClearIndex;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/indexing/BatchOperation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/indexing/BatchOperation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$DeleteIndex : com/algolia/search/model/indexing/BatchOperation {
+	public static final field INSTANCE Lcom/algolia/search/model/indexing/BatchOperation$DeleteIndex;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$DeleteObject : com/algolia/search/model/indexing/BatchOperation {
+	public fun <init> (Lcom/algolia/search/model/ObjectID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;)Lcom/algolia/search/model/indexing/BatchOperation$DeleteObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/BatchOperation$DeleteObject;Lcom/algolia/search/model/ObjectID;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$DeleteObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$Other : com/algolia/search/model/indexing/BatchOperation {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/indexing/BatchOperation$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/BatchOperation$Other;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$PartialUpdateObject : com/algolia/search/model/indexing/BatchOperation {
+	public static final field Companion Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject$Companion;
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component3 ()Z
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Z)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ZILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreateIfNotExists ()Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$PartialUpdateObject$Companion {
+	public final fun from (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/indexing/Partial;Z)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+	public final fun from (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;Z)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+	public static synthetic fun from$default (Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject$Companion;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/indexing/Partial;ZILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+	public static synthetic fun from$default (Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject$Companion;Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;ZILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$PartialUpdateObject;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$ReplaceObject : com/algolia/search/model/indexing/BatchOperation {
+	public static final field Companion Lcom/algolia/search/model/indexing/BatchOperation$ReplaceObject$Companion;
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/indexing/BatchOperation$ReplaceObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/BatchOperation$ReplaceObject;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/BatchOperation$ReplaceObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/BatchOperation$ReplaceObject$Companion {
+	public final fun from (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;)Lcom/algolia/search/model/indexing/BatchOperation$ReplaceObject;
+}
+
+public final class com/algolia/search/model/indexing/DeleteByQuery {
+	public static final field Companion Lcom/algolia/search/model/indexing/DeleteByQuery$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lcom/algolia/search/model/search/Point;
+	public final fun component6 ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun component7 ()Lcom/algolia/search/model/search/AroundPrecision;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/util/List;Ljava/util/List;)Lcom/algolia/search/model/indexing/DeleteByQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/DeleteByQuery;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/DeleteByQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public final fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public final fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun getFacetFilters ()Ljava/util/List;
+	public final fun getFilters ()Ljava/lang/String;
+	public final fun getInsideBoundingBox ()Ljava/util/List;
+	public final fun getInsidePolygon ()Ljava/util/List;
+	public final fun getNumericFilters ()Ljava/util/List;
+	public final fun getTagFilters ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public final fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public final fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public final fun setFacetFilters (Ljava/util/List;)V
+	public final fun setFilters (Ljava/lang/String;)V
+	public final fun setInsideBoundingBox (Ljava/util/List;)V
+	public final fun setInsidePolygon (Ljava/util/List;)V
+	public final fun setNumericFilters (Ljava/util/List;)V
+	public final fun setTagFilters (Ljava/util/List;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/indexing/DeleteByQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/indexing/DeleteByQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/indexing/DeleteByQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/indexing/DeleteByQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/indexing/DeleteByQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/indexing/DeleteByQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/indexing/Indexable {
+	public abstract fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+}
+
+public abstract class com/algolia/search/model/indexing/Partial {
+	public static final field Companion Lcom/algolia/search/model/indexing/Partial$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public abstract fun getAttribute ()Lcom/algolia/search/model/Attribute;
+}
+
+public final class com/algolia/search/model/indexing/Partial$Add : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$Add;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$Add;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$Add;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$AddUnique : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$AddUnique;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$AddUnique;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$AddUnique;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/indexing/Partial;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/indexing/Partial;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/model/indexing/Partial$Decrement : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$Decrement;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$Decrement;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$Decrement;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$Increment : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$Increment;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$Increment;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$Increment;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$IncrementFrom : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$IncrementFrom;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$IncrementFrom;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$IncrementFrom;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$IncrementSet : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$IncrementSet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$IncrementSet;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$IncrementSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$Remove : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$Remove;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$Remove;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$Remove;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/indexing/Partial$Update : com/algolia/search/model/indexing/Partial {
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Number;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/String;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonArray;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonObject;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Z)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/indexing/Partial$Update;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/indexing/Partial$Update;Lcom/algolia/search/model/Attribute;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/indexing/Partial$Update;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/EventName : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/insights/EventName$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/insights/EventName;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/EventName;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/insights/EventName;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/EventName$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/insights/EventName;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/insights/EventName;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/insights/InsightsEvent {
+	public static final field Companion Lcom/algolia/search/model/insights/InsightsEvent$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public abstract fun getEventName ()Lcom/algolia/search/model/insights/EventName;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public abstract fun getResources ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public abstract fun getTimestamp ()Ljava/lang/Long;
+	public abstract fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$Click : com/algolia/search/model/insights/InsightsEvent {
+	public fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/insights/EventName;
+	public final fun component2 ()Lcom/algolia/search/model/IndexName;
+	public final fun component3 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lcom/algolia/search/model/QueryID;
+	public final fun component6 ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;Ljava/util/List;)Lcom/algolia/search/model/insights/InsightsEvent$Click;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/InsightsEvent$Click;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/insights/InsightsEvent$Click;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventName ()Lcom/algolia/search/model/insights/EventName;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getPositions ()Ljava/util/List;
+	public fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public fun getResources ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public fun getTimestamp ()Ljava/lang/Long;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/insights/InsightsEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/insights/InsightsEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$Conversion : com/algolia/search/model/insights/InsightsEvent {
+	public fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/insights/EventName;
+	public final fun component2 ()Lcom/algolia/search/model/IndexName;
+	public final fun component3 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lcom/algolia/search/model/QueryID;
+	public final fun component6 ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public final fun copy (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;)Lcom/algolia/search/model/insights/InsightsEvent$Conversion;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/InsightsEvent$Conversion;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;ILjava/lang/Object;)Lcom/algolia/search/model/insights/InsightsEvent$Conversion;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventName ()Lcom/algolia/search/model/insights/EventName;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public fun getResources ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public fun getTimestamp ()Ljava/lang/Long;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/insights/InsightsEvent$Resources {
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$Resources$Filters : com/algolia/search/model/insights/InsightsEvent$Resources {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/insights/InsightsEvent$Resources$Filters;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/InsightsEvent$Resources$Filters;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/insights/InsightsEvent$Resources$Filters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$Resources$ObjectIDs : com/algolia/search/model/insights/InsightsEvent$Resources {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/insights/InsightsEvent$Resources$ObjectIDs;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/InsightsEvent$Resources$ObjectIDs;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/insights/InsightsEvent$Resources$ObjectIDs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectIDs ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/InsightsEvent$View : com/algolia/search/model/insights/InsightsEvent {
+	public fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/insights/EventName;
+	public final fun component2 ()Lcom/algolia/search/model/IndexName;
+	public final fun component3 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lcom/algolia/search/model/QueryID;
+	public final fun component6 ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public final fun copy (Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;)Lcom/algolia/search/model/insights/InsightsEvent$View;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/InsightsEvent$View;Lcom/algolia/search/model/insights/EventName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/Long;Lcom/algolia/search/model/QueryID;Lcom/algolia/search/model/insights/InsightsEvent$Resources;ILjava/lang/Object;)Lcom/algolia/search/model/insights/InsightsEvent$View;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventName ()Lcom/algolia/search/model/insights/EventName;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public fun getResources ()Lcom/algolia/search/model/insights/InsightsEvent$Resources;
+	public fun getTimestamp ()Ljava/lang/Long;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/UserToken : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/insights/UserToken$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/insights/UserToken;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/insights/UserToken;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/insights/UserToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/insights/UserToken$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/insights/UserToken;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/insights/UserToken;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multicluster/ClusterName : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/multicluster/ClusterName$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/multicluster/ClusterName;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/multicluster/ClusterName;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/multicluster/ClusterName$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multicluster/ClusterName;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multicluster/ClusterName;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multicluster/UserID : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/multicluster/UserID$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/multicluster/UserID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multicluster/UserID;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/multicluster/UserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/multicluster/UserID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multicluster/UserID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multicluster/UserID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multicluster/UserIDQuery {
+	public static final field Companion Lcom/algolia/search/model/multicluster/UserIDQuery$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/algolia/search/model/multicluster/UserIDQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multicluster/UserIDQuery;Ljava/lang/String;Lcom/algolia/search/model/multicluster/ClusterName;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/algolia/search/model/multicluster/UserIDQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClusterName ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun getHitsPerPage ()Ljava/lang/Integer;
+	public final fun getPage ()Ljava/lang/Integer;
+	public final fun getQuery ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setClusterName (Lcom/algolia/search/model/multicluster/ClusterName;)V
+	public final fun setHitsPerPage (Ljava/lang/Integer;)V
+	public final fun setPage (Ljava/lang/Integer;)V
+	public final fun setQuery (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/multicluster/UserIDQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/multicluster/UserIDQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/multicluster/UserIDQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multicluster/UserIDQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multicluster/UserIDQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multicluster/UserIDQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multipleindex/BatchOperationIndex {
+	public static final field Companion Lcom/algolia/search/model/multipleindex/BatchOperationIndex$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/indexing/BatchOperation;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/indexing/BatchOperation;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/indexing/BatchOperation;)Lcom/algolia/search/model/multipleindex/BatchOperationIndex;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multipleindex/BatchOperationIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/indexing/BatchOperation;ILjava/lang/Object;)Lcom/algolia/search/model/multipleindex/BatchOperationIndex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getOperation ()Lcom/algolia/search/model/indexing/BatchOperation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/multipleindex/BatchOperationIndex$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multipleindex/BatchOperationIndex;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multipleindex/BatchOperationIndex;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multipleindex/FacetIndexQuery : com/algolia/search/model/multipleindex/IndexedQuery {
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;Lcom/algolia/search/model/Attribute;)V
+	public final fun getFacetAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getQuery ()Lcom/algolia/search/model/search/Query;
+}
+
+public final class com/algolia/search/model/multipleindex/IndexQuery : com/algolia/search/model/multipleindex/IndexedQuery {
+	public static final field Companion Lcom/algolia/search/model/multipleindex/IndexQuery$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/search/Query;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;)Lcom/algolia/search/model/multipleindex/IndexQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multipleindex/IndexQuery;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/search/Query;ILjava/lang/Object;)Lcom/algolia/search/model/multipleindex/IndexQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getQuery ()Lcom/algolia/search/model/search/Query;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/multipleindex/IndexQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/multipleindex/IndexQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/multipleindex/IndexQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multipleindex/IndexQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multipleindex/IndexQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multipleindex/IndexQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/multipleindex/IndexedQuery {
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getQuery ()Lcom/algolia/search/model/search/Query;
+}
+
+public abstract class com/algolia/search/model/multipleindex/MultipleQueriesStrategy : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/multipleindex/MultipleQueriesStrategy$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multipleindex/MultipleQueriesStrategy$None : com/algolia/search/model/multipleindex/MultipleQueriesStrategy {
+	public static final field INSTANCE Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$None;
+}
+
+public final class com/algolia/search/model/multipleindex/MultipleQueriesStrategy$Other : com/algolia/search/model/multipleindex/MultipleQueriesStrategy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/multipleindex/MultipleQueriesStrategy$StopIfEnoughMatches : com/algolia/search/model/multipleindex/MultipleQueriesStrategy {
+	public static final field INSTANCE Lcom/algolia/search/model/multipleindex/MultipleQueriesStrategy$StopIfEnoughMatches;
+}
+
+public final class com/algolia/search/model/multipleindex/RequestObjects {
+	public static final field Companion Lcom/algolia/search/model/multipleindex/RequestObjects$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;Ljava/util/List;)Lcom/algolia/search/model/multipleindex/RequestObjects;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/multipleindex/RequestObjects;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/multipleindex/RequestObjects;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/List;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/multipleindex/RequestObjects;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/multipleindex/RequestObjects$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/multipleindex/RequestObjects$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/multipleindex/RequestObjects;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/multipleindex/RequestObjects;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/multipleindex/RequestObjects$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/params/AnswersParameters : com/algolia/search/model/params/CommonSearchParameters {
+	public abstract fun getQuery ()Ljava/lang/String;
+	public abstract fun setQuery (Ljava/lang/String;)V
+}
+
+public abstract interface class com/algolia/search/model/params/BaseParameters {
+	public abstract fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public abstract fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public abstract fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public abstract fun getAlternativesAsExact ()Ljava/util/List;
+	public abstract fun getAttributesToHighlight ()Ljava/util/List;
+	public abstract fun getAttributesToRetrieve ()Ljava/util/List;
+	public abstract fun getDisableExactOnAttributes ()Ljava/util/List;
+	public abstract fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public abstract fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public abstract fun getEnableRules ()Ljava/lang/Boolean;
+	public abstract fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public abstract fun getHighlightPostTag ()Ljava/lang/String;
+	public abstract fun getHighlightPreTag ()Ljava/lang/String;
+	public abstract fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public abstract fun getMaxFacetHits ()Ljava/lang/Integer;
+	public abstract fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public abstract fun getMinProximity ()Ljava/lang/Integer;
+	public abstract fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public abstract fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public abstract fun getOptionalWords ()Ljava/util/List;
+	public abstract fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public abstract fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public abstract fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public abstract fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public abstract fun getResponseFields ()Ljava/util/List;
+	public abstract fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public abstract fun getSnippetEllipsisText ()Ljava/lang/String;
+	public abstract fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public abstract fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public abstract fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public abstract fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public abstract fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public abstract fun setAlternativesAsExact (Ljava/util/List;)V
+	public abstract fun setAttributesToHighlight (Ljava/util/List;)V
+	public abstract fun setAttributesToRetrieve (Ljava/util/List;)V
+	public abstract fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public abstract fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public abstract fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public abstract fun setEnableRules (Ljava/lang/Boolean;)V
+	public abstract fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public abstract fun setHighlightPostTag (Ljava/lang/String;)V
+	public abstract fun setHighlightPreTag (Ljava/lang/String;)V
+	public abstract fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public abstract fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public abstract fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public abstract fun setMinProximity (Ljava/lang/Integer;)V
+	public abstract fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public abstract fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public abstract fun setOptionalWords (Ljava/util/List;)V
+	public abstract fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public abstract fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public abstract fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public abstract fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public abstract fun setResponseFields (Ljava/util/List;)V
+	public abstract fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public abstract fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public abstract fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public abstract fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+}
+
+public abstract interface class com/algolia/search/model/params/CommonParameters : com/algolia/search/model/params/BaseParameters {
+	public abstract fun getAttributesToSnippet ()Ljava/util/List;
+	public abstract fun getDecompoundQuery ()Ljava/lang/Boolean;
+	public abstract fun getHitsPerPage ()Ljava/lang/Integer;
+	public abstract fun getQueryLanguages ()Ljava/util/List;
+	public abstract fun getRelevancyStrictness ()Ljava/lang/Integer;
+	public abstract fun setAttributesToSnippet (Ljava/util/List;)V
+	public abstract fun setDecompoundQuery (Ljava/lang/Boolean;)V
+	public abstract fun setHitsPerPage (Ljava/lang/Integer;)V
+	public abstract fun setQueryLanguages (Ljava/util/List;)V
+	public abstract fun setRelevancyStrictness (Ljava/lang/Integer;)V
+}
+
+public abstract interface class com/algolia/search/model/params/CommonSearchParameters : com/algolia/search/model/params/BaseParameters {
+	public abstract fun getAnalytics ()Ljava/lang/Boolean;
+	public abstract fun getAnalyticsTags ()Ljava/util/List;
+	public abstract fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public abstract fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public abstract fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public abstract fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public abstract fun getClickAnalytics ()Ljava/lang/Boolean;
+	public abstract fun getEnableABTest ()Ljava/lang/Boolean;
+	public abstract fun getEnablePersonalization ()Ljava/lang/Boolean;
+	public abstract fun getExplainModules ()Ljava/util/List;
+	public abstract fun getFacetFilters ()Ljava/util/List;
+	public abstract fun getFacetingAfterDistinct ()Ljava/lang/Boolean;
+	public abstract fun getFacets ()Ljava/util/Set;
+	public abstract fun getFilters ()Ljava/lang/String;
+	public abstract fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public abstract fun getInsideBoundingBox ()Ljava/util/List;
+	public abstract fun getInsidePolygon ()Ljava/util/List;
+	public abstract fun getLength ()Ljava/lang/Integer;
+	public abstract fun getMinimumAroundRadius ()Ljava/lang/Integer;
+	public abstract fun getNaturalLanguages ()Ljava/util/List;
+	public abstract fun getNumericFilters ()Ljava/util/List;
+	public abstract fun getOffset ()Ljava/lang/Integer;
+	public abstract fun getOptionalFilters ()Ljava/util/List;
+	public abstract fun getPage ()Ljava/lang/Integer;
+	public abstract fun getPercentileComputation ()Ljava/lang/Boolean;
+	public abstract fun getPersonalizationImpact ()Ljava/lang/Integer;
+	public abstract fun getRuleContexts ()Ljava/util/List;
+	public abstract fun getSimilarQuery ()Ljava/lang/String;
+	public abstract fun getSumOrFiltersScores ()Ljava/lang/Boolean;
+	public abstract fun getSynonyms ()Ljava/lang/Boolean;
+	public abstract fun getTagFilters ()Ljava/util/List;
+	public abstract fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public abstract fun setAnalytics (Ljava/lang/Boolean;)V
+	public abstract fun setAnalyticsTags (Ljava/util/List;)V
+	public abstract fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public abstract fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public abstract fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public abstract fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public abstract fun setClickAnalytics (Ljava/lang/Boolean;)V
+	public abstract fun setEnableABTest (Ljava/lang/Boolean;)V
+	public abstract fun setEnablePersonalization (Ljava/lang/Boolean;)V
+	public abstract fun setExplainModules (Ljava/util/List;)V
+	public abstract fun setFacetFilters (Ljava/util/List;)V
+	public abstract fun setFacetingAfterDistinct (Ljava/lang/Boolean;)V
+	public abstract fun setFacets (Ljava/util/Set;)V
+	public abstract fun setFilters (Ljava/lang/String;)V
+	public abstract fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public abstract fun setInsideBoundingBox (Ljava/util/List;)V
+	public abstract fun setInsidePolygon (Ljava/util/List;)V
+	public abstract fun setLength (Ljava/lang/Integer;)V
+	public abstract fun setMinimumAroundRadius (Ljava/lang/Integer;)V
+	public abstract fun setNaturalLanguages (Ljava/util/List;)V
+	public abstract fun setNumericFilters (Ljava/util/List;)V
+	public abstract fun setOffset (Ljava/lang/Integer;)V
+	public abstract fun setOptionalFilters (Ljava/util/List;)V
+	public abstract fun setPage (Ljava/lang/Integer;)V
+	public abstract fun setPercentileComputation (Ljava/lang/Boolean;)V
+	public abstract fun setPersonalizationImpact (Ljava/lang/Integer;)V
+	public abstract fun setRuleContexts (Ljava/util/List;)V
+	public abstract fun setSimilarQuery (Ljava/lang/String;)V
+	public abstract fun setSumOrFiltersScores (Ljava/lang/Boolean;)V
+	public abstract fun setSynonyms (Ljava/lang/Boolean;)V
+	public abstract fun setTagFilters (Ljava/util/List;)V
+	public abstract fun setUserToken (Lcom/algolia/search/model/insights/UserToken;)V
+}
+
+public abstract interface class com/algolia/search/model/params/SearchParameters : com/algolia/search/model/params/CommonParameters, com/algolia/search/model/params/CommonSearchParameters {
+	public abstract fun getEnableReRanking ()Ljava/lang/Boolean;
+	public abstract fun getQuery ()Ljava/lang/String;
+	public abstract fun getRestrictSearchableAttributes ()Ljava/util/List;
+	public abstract fun setEnableReRanking (Ljava/lang/Boolean;)V
+	public abstract fun setQuery (Ljava/lang/String;)V
+	public abstract fun setRestrictSearchableAttributes (Ljava/util/List;)V
+}
+
+public abstract interface class com/algolia/search/model/params/SettingsParameters : com/algolia/search/model/params/CommonParameters {
+	public abstract fun getAllowCompressionOfIntegerArray ()Ljava/lang/Boolean;
+	public abstract fun getAttributeCriteriaComputedByMinProximity ()Ljava/lang/Boolean;
+	public abstract fun getAttributeForDistinct ()Lcom/algolia/search/model/Attribute;
+	public abstract fun getAttributesForFaceting ()Ljava/util/List;
+	public abstract fun getAttributesToTransliterate ()Ljava/util/List;
+	public abstract fun getCamelCaseAttributes ()Ljava/util/List;
+	public abstract fun getCustomNormalization ()Ljava/util/Map;
+	public abstract fun getCustomRanking ()Ljava/util/List;
+	public abstract fun getDecompoundedAttributes ()Ljava/util/List;
+	public abstract fun getDisablePrefixOnAttributes ()Ljava/util/List;
+	public abstract fun getDisableTypoToleranceOnWords ()Ljava/util/List;
+	public abstract fun getEnablePersonalization ()Z
+	public abstract fun getIndexLanguages ()Ljava/util/List;
+	public abstract fun getKeepDiacriticsOnCharacters ()Ljava/lang/String;
+	public abstract fun getNumericAttributesForFiltering ()Ljava/util/List;
+	public abstract fun getPaginationLimitedTo ()Ljava/lang/Integer;
+	public abstract fun getRanking ()Ljava/util/List;
+	public abstract fun getRenderingContent ()Lcom/algolia/search/model/rule/RenderingContent;
+	public abstract fun getReplicas ()Ljava/util/List;
+	public abstract fun getSearchableAttributes ()Ljava/util/List;
+	public abstract fun getSeparatorsToIndex ()Ljava/lang/String;
+	public abstract fun getUnretrievableAttributes ()Ljava/util/List;
+	public abstract fun getUserData ()Lkotlinx/serialization/json/JsonObject;
+	public abstract fun getVersion ()Ljava/lang/Integer;
+	public abstract fun setAllowCompressionOfIntegerArray (Ljava/lang/Boolean;)V
+	public abstract fun setAttributeCriteriaComputedByMinProximity (Ljava/lang/Boolean;)V
+	public abstract fun setAttributeForDistinct (Lcom/algolia/search/model/Attribute;)V
+	public abstract fun setAttributesForFaceting (Ljava/util/List;)V
+	public abstract fun setAttributesToTransliterate (Ljava/util/List;)V
+	public abstract fun setCamelCaseAttributes (Ljava/util/List;)V
+	public abstract fun setCustomNormalization (Ljava/util/Map;)V
+	public abstract fun setCustomRanking (Ljava/util/List;)V
+	public abstract fun setDecompoundedAttributes (Ljava/util/List;)V
+	public abstract fun setDisablePrefixOnAttributes (Ljava/util/List;)V
+	public abstract fun setDisableTypoToleranceOnWords (Ljava/util/List;)V
+	public abstract fun setEnablePersonalization (Z)V
+	public abstract fun setIndexLanguages (Ljava/util/List;)V
+	public abstract fun setKeepDiacriticsOnCharacters (Ljava/lang/String;)V
+	public abstract fun setNumericAttributesForFiltering (Ljava/util/List;)V
+	public abstract fun setPaginationLimitedTo (Ljava/lang/Integer;)V
+	public abstract fun setRanking (Ljava/util/List;)V
+	public abstract fun setRenderingContent (Lcom/algolia/search/model/rule/RenderingContent;)V
+	public abstract fun setReplicas (Ljava/util/List;)V
+	public abstract fun setSearchableAttributes (Ljava/util/List;)V
+	public abstract fun setSeparatorsToIndex (Ljava/lang/String;)V
+	public abstract fun setUnretrievableAttributes (Ljava/util/List;)V
+	public abstract fun setUserData (Lkotlinx/serialization/json/JsonObject;)V
+	public abstract fun setVersion (Ljava/lang/Integer;)V
+}
+
+public final class com/algolia/search/model/personalization/EventScoring {
+	public static final field Companion Lcom/algolia/search/model/personalization/EventScoring$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;I)Lcom/algolia/search/model/personalization/EventScoring;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/personalization/EventScoring;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lcom/algolia/search/model/personalization/EventScoring;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEventName ()Ljava/lang/String;
+	public final fun getEventType ()Ljava/lang/String;
+	public final fun getScore ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/personalization/EventScoring;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/personalization/EventScoring$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/personalization/EventScoring$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/personalization/EventScoring;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/personalization/EventScoring;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/EventScoring$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/FacetScoring {
+	public static final field Companion Lcom/algolia/search/model/personalization/FacetScoring$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lcom/algolia/search/model/personalization/FacetScoring;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/personalization/FacetScoring;Ljava/lang/String;IILjava/lang/Object;)Lcom/algolia/search/model/personalization/FacetScoring;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFacetName ()Ljava/lang/String;
+	public final fun getScore ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/personalization/FacetScoring;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/personalization/FacetScoring$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/personalization/FacetScoring$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/personalization/FacetScoring;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/personalization/FacetScoring;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/FacetScoring$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationProfileResponse {
+	public static final field Companion Lcom/algolia/search/model/personalization/PersonalizationProfileResponse$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/insights/UserToken;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/insights/UserToken;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/insights/UserToken;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;Lcom/algolia/search/model/insights/UserToken;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastEventAt ()Ljava/lang/String;
+	public final fun getScores ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationProfileResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/personalization/PersonalizationProfileResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/personalization/PersonalizationProfileResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationProfileResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationStrategy {
+	public static final field Companion Lcom/algolia/search/model/personalization/PersonalizationStrategy$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;Ljava/util/List;I)Lcom/algolia/search/model/personalization/PersonalizationStrategy;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/personalization/PersonalizationStrategy;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lcom/algolia/search/model/personalization/PersonalizationStrategy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEventsScoring ()Ljava/util/List;
+	public final fun getFacetsScoring ()Ljava/util/List;
+	public final fun getPersonalizationImpact ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/personalization/PersonalizationStrategy;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationStrategy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/personalization/PersonalizationStrategy$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/personalization/PersonalizationStrategy;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/personalization/PersonalizationStrategy;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/PersonalizationStrategy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/SetPersonalizationStrategyResponse {
+	public static final field Companion Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse$Companion;
+	public synthetic fun <init> (IILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;ILjava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStatus ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/personalization/SetPersonalizationStrategyResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/personalization/SetPersonalizationStrategyResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/personalization/SetPersonalizationStrategyResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/places/Country : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/places/Country$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/places/Country$Afghanistan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Afghanistan;
+}
+
+public final class com/algolia/search/model/places/Country$AlandIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$AlandIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Albania : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Albania;
+}
+
+public final class com/algolia/search/model/places/Country$Algeria : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Algeria;
+}
+
+public final class com/algolia/search/model/places/Country$AmericanSamoa : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$AmericanSamoa;
+}
+
+public final class com/algolia/search/model/places/Country$Andorra : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Andorra;
+}
+
+public final class com/algolia/search/model/places/Country$Angola : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Angola;
+}
+
+public final class com/algolia/search/model/places/Country$Anguilla : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Anguilla;
+}
+
+public final class com/algolia/search/model/places/Country$Antarctica : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Antarctica;
+}
+
+public final class com/algolia/search/model/places/Country$AntiguaAndBarbuda : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$AntiguaAndBarbuda;
+}
+
+public final class com/algolia/search/model/places/Country$Argentina : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Argentina;
+}
+
+public final class com/algolia/search/model/places/Country$Armenia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Armenia;
+}
+
+public final class com/algolia/search/model/places/Country$Aruba : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Aruba;
+}
+
+public final class com/algolia/search/model/places/Country$Australia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Australia;
+}
+
+public final class com/algolia/search/model/places/Country$Austria : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Austria;
+}
+
+public final class com/algolia/search/model/places/Country$Azerbaijan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Azerbaijan;
+}
+
+public final class com/algolia/search/model/places/Country$Bahamas : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bahamas;
+}
+
+public final class com/algolia/search/model/places/Country$Bahrain : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bahrain;
+}
+
+public final class com/algolia/search/model/places/Country$BailiwickOfGuernsey : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BailiwickOfGuernsey;
+}
+
+public final class com/algolia/search/model/places/Country$Bangladesh : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bangladesh;
+}
+
+public final class com/algolia/search/model/places/Country$Barbados : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Barbados;
+}
+
+public final class com/algolia/search/model/places/Country$Belarus : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Belarus;
+}
+
+public final class com/algolia/search/model/places/Country$Belgium : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Belgium;
+}
+
+public final class com/algolia/search/model/places/Country$Belize : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Belize;
+}
+
+public final class com/algolia/search/model/places/Country$Benin : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Benin;
+}
+
+public final class com/algolia/search/model/places/Country$Bermuda : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bermuda;
+}
+
+public final class com/algolia/search/model/places/Country$Bhutan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bhutan;
+}
+
+public final class com/algolia/search/model/places/Country$Bolivia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bolivia;
+}
+
+public final class com/algolia/search/model/places/Country$BosniaAndHerzegovina : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BosniaAndHerzegovina;
+}
+
+public final class com/algolia/search/model/places/Country$Botswana : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Botswana;
+}
+
+public final class com/algolia/search/model/places/Country$BouvetIsland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BouvetIsland;
+}
+
+public final class com/algolia/search/model/places/Country$Brazil : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Brazil;
+}
+
+public final class com/algolia/search/model/places/Country$BritishIndianOceanTerritory : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BritishIndianOceanTerritory;
+}
+
+public final class com/algolia/search/model/places/Country$BruneiDarussalam : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BruneiDarussalam;
+}
+
+public final class com/algolia/search/model/places/Country$Bulgaria : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Bulgaria;
+}
+
+public final class com/algolia/search/model/places/Country$BurkinaFaso : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$BurkinaFaso;
+}
+
+public final class com/algolia/search/model/places/Country$Burundi : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Burundi;
+}
+
+public final class com/algolia/search/model/places/Country$CaboVerde : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CaboVerde;
+}
+
+public final class com/algolia/search/model/places/Country$Cambodia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Cambodia;
+}
+
+public final class com/algolia/search/model/places/Country$Cameroon : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Cameroon;
+}
+
+public final class com/algolia/search/model/places/Country$Canada : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Canada;
+}
+
+public final class com/algolia/search/model/places/Country$CaribbeanNetherlands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CaribbeanNetherlands;
+}
+
+public final class com/algolia/search/model/places/Country$CaymanIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CaymanIslands;
+}
+
+public final class com/algolia/search/model/places/Country$CentralAfricanRepublic : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CentralAfricanRepublic;
+}
+
+public final class com/algolia/search/model/places/Country$Chad : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Chad;
+}
+
+public final class com/algolia/search/model/places/Country$Chile : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Chile;
+}
+
+public final class com/algolia/search/model/places/Country$China : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$China;
+}
+
+public final class com/algolia/search/model/places/Country$ChristmasIsland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$ChristmasIsland;
+}
+
+public final class com/algolia/search/model/places/Country$CocosIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CocosIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Colombia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Colombia;
+}
+
+public final class com/algolia/search/model/places/Country$Comoros : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Comoros;
+}
+
+public final class com/algolia/search/model/places/Country$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/places/Country;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/places/Country;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/Country$CookIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CookIslands;
+}
+
+public final class com/algolia/search/model/places/Country$CostaRica : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CostaRica;
+}
+
+public final class com/algolia/search/model/places/Country$Croatia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Croatia;
+}
+
+public final class com/algolia/search/model/places/Country$Cuba : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Cuba;
+}
+
+public final class com/algolia/search/model/places/Country$Curacao : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Curacao;
+}
+
+public final class com/algolia/search/model/places/Country$Cyprus : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Cyprus;
+}
+
+public final class com/algolia/search/model/places/Country$CzechRepublic : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$CzechRepublic;
+}
+
+public final class com/algolia/search/model/places/Country$DemocraticRepublicOfTheCongo : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$DemocraticRepublicOfTheCongo;
+}
+
+public final class com/algolia/search/model/places/Country$Denmark : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Denmark;
+}
+
+public final class com/algolia/search/model/places/Country$Djibouti : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Djibouti;
+}
+
+public final class com/algolia/search/model/places/Country$Dominica : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Dominica;
+}
+
+public final class com/algolia/search/model/places/Country$DominicanRepublic : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$DominicanRepublic;
+}
+
+public final class com/algolia/search/model/places/Country$Ecuador : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Ecuador;
+}
+
+public final class com/algolia/search/model/places/Country$Egypt : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Egypt;
+}
+
+public final class com/algolia/search/model/places/Country$ElSalvador : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$ElSalvador;
+}
+
+public final class com/algolia/search/model/places/Country$EquatorialGuinea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$EquatorialGuinea;
+}
+
+public final class com/algolia/search/model/places/Country$Eritrea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Eritrea;
+}
+
+public final class com/algolia/search/model/places/Country$Estonia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Estonia;
+}
+
+public final class com/algolia/search/model/places/Country$Eswatini : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Eswatini;
+}
+
+public final class com/algolia/search/model/places/Country$Ethiopia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Ethiopia;
+}
+
+public final class com/algolia/search/model/places/Country$FalklandIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$FalklandIslands;
+}
+
+public final class com/algolia/search/model/places/Country$FaroeIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$FaroeIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Fiji : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Fiji;
+}
+
+public final class com/algolia/search/model/places/Country$Finland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Finland;
+}
+
+public final class com/algolia/search/model/places/Country$France : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$France;
+}
+
+public final class com/algolia/search/model/places/Country$FrenchGuiana : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$FrenchGuiana;
+}
+
+public final class com/algolia/search/model/places/Country$FrenchPolynesia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$FrenchPolynesia;
+}
+
+public final class com/algolia/search/model/places/Country$FrenchSouthernAndAntarcticLands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$FrenchSouthernAndAntarcticLands;
+}
+
+public final class com/algolia/search/model/places/Country$Gabon : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Gabon;
+}
+
+public final class com/algolia/search/model/places/Country$Gambia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Gambia;
+}
+
+public final class com/algolia/search/model/places/Country$Georgia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Georgia;
+}
+
+public final class com/algolia/search/model/places/Country$Germany : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Germany;
+}
+
+public final class com/algolia/search/model/places/Country$Ghana : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Ghana;
+}
+
+public final class com/algolia/search/model/places/Country$Gibraltar : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Gibraltar;
+}
+
+public final class com/algolia/search/model/places/Country$Greece : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Greece;
+}
+
+public final class com/algolia/search/model/places/Country$Greenland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Greenland;
+}
+
+public final class com/algolia/search/model/places/Country$Grenada : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Grenada;
+}
+
+public final class com/algolia/search/model/places/Country$Guadeloupe : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Guadeloupe;
+}
+
+public final class com/algolia/search/model/places/Country$Guam : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Guam;
+}
+
+public final class com/algolia/search/model/places/Country$Guatemala : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Guatemala;
+}
+
+public final class com/algolia/search/model/places/Country$Guinea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Guinea;
+}
+
+public final class com/algolia/search/model/places/Country$GuineaBissau : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$GuineaBissau;
+}
+
+public final class com/algolia/search/model/places/Country$Guyana : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Guyana;
+}
+
+public final class com/algolia/search/model/places/Country$Haiti : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Haiti;
+}
+
+public final class com/algolia/search/model/places/Country$HeardIslandAndMcDonaldIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$HeardIslandAndMcDonaldIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Honduras : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Honduras;
+}
+
+public final class com/algolia/search/model/places/Country$HongKong : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$HongKong;
+}
+
+public final class com/algolia/search/model/places/Country$Hungary : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Hungary;
+}
+
+public final class com/algolia/search/model/places/Country$Iceland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Iceland;
+}
+
+public final class com/algolia/search/model/places/Country$India : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$India;
+}
+
+public final class com/algolia/search/model/places/Country$Indonesia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Indonesia;
+}
+
+public final class com/algolia/search/model/places/Country$Iran : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Iran;
+}
+
+public final class com/algolia/search/model/places/Country$Iraq : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Iraq;
+}
+
+public final class com/algolia/search/model/places/Country$Ireland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Ireland;
+}
+
+public final class com/algolia/search/model/places/Country$IsleOfMan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$IsleOfMan;
+}
+
+public final class com/algolia/search/model/places/Country$Israel : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Israel;
+}
+
+public final class com/algolia/search/model/places/Country$Italy : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Italy;
+}
+
+public final class com/algolia/search/model/places/Country$IvoryCoast : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$IvoryCoast;
+}
+
+public final class com/algolia/search/model/places/Country$Jamaica : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Jamaica;
+}
+
+public final class com/algolia/search/model/places/Country$Japan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Japan;
+}
+
+public final class com/algolia/search/model/places/Country$Jersey : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Jersey;
+}
+
+public final class com/algolia/search/model/places/Country$Jordan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Jordan;
+}
+
+public final class com/algolia/search/model/places/Country$Kazakhstan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Kazakhstan;
+}
+
+public final class com/algolia/search/model/places/Country$Kenya : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Kenya;
+}
+
+public final class com/algolia/search/model/places/Country$Kiribati : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Kiribati;
+}
+
+public final class com/algolia/search/model/places/Country$Kuwait : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Kuwait;
+}
+
+public final class com/algolia/search/model/places/Country$Kyrgyzstan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Kyrgyzstan;
+}
+
+public final class com/algolia/search/model/places/Country$Laos : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Laos;
+}
+
+public final class com/algolia/search/model/places/Country$Latvia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Latvia;
+}
+
+public final class com/algolia/search/model/places/Country$Lebanon : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Lebanon;
+}
+
+public final class com/algolia/search/model/places/Country$Lesotho : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Lesotho;
+}
+
+public final class com/algolia/search/model/places/Country$Liberia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Liberia;
+}
+
+public final class com/algolia/search/model/places/Country$Libya : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Libya;
+}
+
+public final class com/algolia/search/model/places/Country$Liechtenstein : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Liechtenstein;
+}
+
+public final class com/algolia/search/model/places/Country$Lithuania : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Lithuania;
+}
+
+public final class com/algolia/search/model/places/Country$Luxembourg : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Luxembourg;
+}
+
+public final class com/algolia/search/model/places/Country$Macau : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Macau;
+}
+
+public final class com/algolia/search/model/places/Country$Madagascar : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Madagascar;
+}
+
+public final class com/algolia/search/model/places/Country$Malawi : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Malawi;
+}
+
+public final class com/algolia/search/model/places/Country$Malaysia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Malaysia;
+}
+
+public final class com/algolia/search/model/places/Country$Maldives : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Maldives;
+}
+
+public final class com/algolia/search/model/places/Country$Mali : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mali;
+}
+
+public final class com/algolia/search/model/places/Country$Malta : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Malta;
+}
+
+public final class com/algolia/search/model/places/Country$MarshallIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$MarshallIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Martinique : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Martinique;
+}
+
+public final class com/algolia/search/model/places/Country$Mauritania : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mauritania;
+}
+
+public final class com/algolia/search/model/places/Country$Mauritius : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mauritius;
+}
+
+public final class com/algolia/search/model/places/Country$Mayotte : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mayotte;
+}
+
+public final class com/algolia/search/model/places/Country$Mexico : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mexico;
+}
+
+public final class com/algolia/search/model/places/Country$Micronesia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Micronesia;
+}
+
+public final class com/algolia/search/model/places/Country$Moldova : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Moldova;
+}
+
+public final class com/algolia/search/model/places/Country$Monaco : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Monaco;
+}
+
+public final class com/algolia/search/model/places/Country$Mongolia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mongolia;
+}
+
+public final class com/algolia/search/model/places/Country$Montenegro : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Montenegro;
+}
+
+public final class com/algolia/search/model/places/Country$Montserrat : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Montserrat;
+}
+
+public final class com/algolia/search/model/places/Country$Morocco : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Morocco;
+}
+
+public final class com/algolia/search/model/places/Country$Mozambique : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Mozambique;
+}
+
+public final class com/algolia/search/model/places/Country$Myanmar : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Myanmar;
+}
+
+public final class com/algolia/search/model/places/Country$Namibia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Namibia;
+}
+
+public final class com/algolia/search/model/places/Country$Nauru : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Nauru;
+}
+
+public final class com/algolia/search/model/places/Country$Nepal : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Nepal;
+}
+
+public final class com/algolia/search/model/places/Country$Netherlands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Netherlands;
+}
+
+public final class com/algolia/search/model/places/Country$NewCaledonia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NewCaledonia;
+}
+
+public final class com/algolia/search/model/places/Country$NewZealand : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NewZealand;
+}
+
+public final class com/algolia/search/model/places/Country$Nicaragua : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Nicaragua;
+}
+
+public final class com/algolia/search/model/places/Country$Niger : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Niger;
+}
+
+public final class com/algolia/search/model/places/Country$Nigeria : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Nigeria;
+}
+
+public final class com/algolia/search/model/places/Country$Niue : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Niue;
+}
+
+public final class com/algolia/search/model/places/Country$NorfolkIsland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NorfolkIsland;
+}
+
+public final class com/algolia/search/model/places/Country$NorthKorea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NorthKorea;
+}
+
+public final class com/algolia/search/model/places/Country$NorthMacedonia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NorthMacedonia;
+}
+
+public final class com/algolia/search/model/places/Country$NorthernMarianaIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$NorthernMarianaIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Norway : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Norway;
+}
+
+public final class com/algolia/search/model/places/Country$Oman : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Oman;
+}
+
+public final class com/algolia/search/model/places/Country$Other : com/algolia/search/model/places/Country {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/places/Country$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/places/Country$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/places/Country$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/places/Country$Pakistan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Pakistan;
+}
+
+public final class com/algolia/search/model/places/Country$Palau : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Palau;
+}
+
+public final class com/algolia/search/model/places/Country$Palestine : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Palestine;
+}
+
+public final class com/algolia/search/model/places/Country$Panama : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Panama;
+}
+
+public final class com/algolia/search/model/places/Country$PapuaNewGuinea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$PapuaNewGuinea;
+}
+
+public final class com/algolia/search/model/places/Country$Paraguay : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Paraguay;
+}
+
+public final class com/algolia/search/model/places/Country$Peru : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Peru;
+}
+
+public final class com/algolia/search/model/places/Country$Philippines : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Philippines;
+}
+
+public final class com/algolia/search/model/places/Country$PitcairnIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$PitcairnIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Poland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Poland;
+}
+
+public final class com/algolia/search/model/places/Country$Portugal : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Portugal;
+}
+
+public final class com/algolia/search/model/places/Country$PuertoRico : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$PuertoRico;
+}
+
+public final class com/algolia/search/model/places/Country$Qatar : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Qatar;
+}
+
+public final class com/algolia/search/model/places/Country$RepublicOfTheCongo : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$RepublicOfTheCongo;
+}
+
+public final class com/algolia/search/model/places/Country$Reunion : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Reunion;
+}
+
+public final class com/algolia/search/model/places/Country$Romania : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Romania;
+}
+
+public final class com/algolia/search/model/places/Country$Russia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Russia;
+}
+
+public final class com/algolia/search/model/places/Country$Rwanda : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Rwanda;
+}
+
+public final class com/algolia/search/model/places/Country$SaintBarthelemy : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintBarthelemy;
+}
+
+public final class com/algolia/search/model/places/Country$SaintHelena : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintHelena;
+}
+
+public final class com/algolia/search/model/places/Country$SaintKittsAndNevis : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintKittsAndNevis;
+}
+
+public final class com/algolia/search/model/places/Country$SaintLucia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintLucia;
+}
+
+public final class com/algolia/search/model/places/Country$SaintMartin : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintMartin;
+}
+
+public final class com/algolia/search/model/places/Country$SaintPierreAndMiquelon : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintPierreAndMiquelon;
+}
+
+public final class com/algolia/search/model/places/Country$SaintVincentAndTheGrenadines : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaintVincentAndTheGrenadines;
+}
+
+public final class com/algolia/search/model/places/Country$Samoa : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Samoa;
+}
+
+public final class com/algolia/search/model/places/Country$SanMarino : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SanMarino;
+}
+
+public final class com/algolia/search/model/places/Country$SaoTomeAndPrincipe : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaoTomeAndPrincipe;
+}
+
+public final class com/algolia/search/model/places/Country$SaudiArabia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SaudiArabia;
+}
+
+public final class com/algolia/search/model/places/Country$Senegal : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Senegal;
+}
+
+public final class com/algolia/search/model/places/Country$Serbia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Serbia;
+}
+
+public final class com/algolia/search/model/places/Country$Seychelles : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Seychelles;
+}
+
+public final class com/algolia/search/model/places/Country$SierraLeone : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SierraLeone;
+}
+
+public final class com/algolia/search/model/places/Country$Singapore : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Singapore;
+}
+
+public final class com/algolia/search/model/places/Country$SintMaarten : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SintMaarten;
+}
+
+public final class com/algolia/search/model/places/Country$Slovakia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Slovakia;
+}
+
+public final class com/algolia/search/model/places/Country$Slovenia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Slovenia;
+}
+
+public final class com/algolia/search/model/places/Country$SolomonIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SolomonIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Somalia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Somalia;
+}
+
+public final class com/algolia/search/model/places/Country$SouthAfrica : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SouthAfrica;
+}
+
+public final class com/algolia/search/model/places/Country$SouthGeorgiaAndTheSouthSandwichIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SouthGeorgiaAndTheSouthSandwichIslands;
+}
+
+public final class com/algolia/search/model/places/Country$SouthKorea : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SouthKorea;
+}
+
+public final class com/algolia/search/model/places/Country$SouthSudan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SouthSudan;
+}
+
+public final class com/algolia/search/model/places/Country$Spain : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Spain;
+}
+
+public final class com/algolia/search/model/places/Country$SriLanka : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SriLanka;
+}
+
+public final class com/algolia/search/model/places/Country$Sudan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Sudan;
+}
+
+public final class com/algolia/search/model/places/Country$Suriname : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Suriname;
+}
+
+public final class com/algolia/search/model/places/Country$SvalbardAndJanMayen : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$SvalbardAndJanMayen;
+}
+
+public final class com/algolia/search/model/places/Country$Sweden : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Sweden;
+}
+
+public final class com/algolia/search/model/places/Country$Switzerland : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Switzerland;
+}
+
+public final class com/algolia/search/model/places/Country$Syria : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Syria;
+}
+
+public final class com/algolia/search/model/places/Country$Taiwan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Taiwan;
+}
+
+public final class com/algolia/search/model/places/Country$Tajikistan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tajikistan;
+}
+
+public final class com/algolia/search/model/places/Country$Tanzania : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tanzania;
+}
+
+public final class com/algolia/search/model/places/Country$Thailand : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Thailand;
+}
+
+public final class com/algolia/search/model/places/Country$TimorLeste : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$TimorLeste;
+}
+
+public final class com/algolia/search/model/places/Country$Togo : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Togo;
+}
+
+public final class com/algolia/search/model/places/Country$Tokelau : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tokelau;
+}
+
+public final class com/algolia/search/model/places/Country$Tonga : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tonga;
+}
+
+public final class com/algolia/search/model/places/Country$TrinidadAndTobago : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$TrinidadAndTobago;
+}
+
+public final class com/algolia/search/model/places/Country$Tunisia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tunisia;
+}
+
+public final class com/algolia/search/model/places/Country$Turkey : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Turkey;
+}
+
+public final class com/algolia/search/model/places/Country$Turkmenistan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Turkmenistan;
+}
+
+public final class com/algolia/search/model/places/Country$TurksAndCaicosIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$TurksAndCaicosIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Tuvalu : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Tuvalu;
+}
+
+public final class com/algolia/search/model/places/Country$Uganda : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Uganda;
+}
+
+public final class com/algolia/search/model/places/Country$Ukraine : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Ukraine;
+}
+
+public final class com/algolia/search/model/places/Country$UnitedArabEmirates : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$UnitedArabEmirates;
+}
+
+public final class com/algolia/search/model/places/Country$UnitedKingdom : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$UnitedKingdom;
+}
+
+public final class com/algolia/search/model/places/Country$UnitedStates : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$UnitedStates;
+}
+
+public final class com/algolia/search/model/places/Country$UnitedStatesMinorOutlyingIslands : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$UnitedStatesMinorOutlyingIslands;
+}
+
+public final class com/algolia/search/model/places/Country$Uruguay : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Uruguay;
+}
+
+public final class com/algolia/search/model/places/Country$Uzbekistan : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Uzbekistan;
+}
+
+public final class com/algolia/search/model/places/Country$Vanuatu : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Vanuatu;
+}
+
+public final class com/algolia/search/model/places/Country$VaticanCity : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$VaticanCity;
+}
+
+public final class com/algolia/search/model/places/Country$Venezuela : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Venezuela;
+}
+
+public final class com/algolia/search/model/places/Country$Vietnam : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Vietnam;
+}
+
+public final class com/algolia/search/model/places/Country$VirginIslandsGB : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$VirginIslandsGB;
+}
+
+public final class com/algolia/search/model/places/Country$VirginIslandsUS : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$VirginIslandsUS;
+}
+
+public final class com/algolia/search/model/places/Country$WallisAndFutuna : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$WallisAndFutuna;
+}
+
+public final class com/algolia/search/model/places/Country$WesternSahara : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$WesternSahara;
+}
+
+public final class com/algolia/search/model/places/Country$Yemen : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Yemen;
+}
+
+public final class com/algolia/search/model/places/Country$Zambia : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Zambia;
+}
+
+public final class com/algolia/search/model/places/Country$Zimbabwe : com/algolia/search/model/places/Country {
+	public static final field INSTANCE Lcom/algolia/search/model/places/Country$Zimbabwe;
+}
+
+public abstract interface class com/algolia/search/model/places/Place {
+	public abstract fun getAdminLevel ()I
+	public abstract fun getAdminLevelOrNull ()Ljava/lang/Integer;
+	public abstract fun getAdministrative ()Ljava/util/List;
+	public abstract fun getAdministrativeOrNull ()Ljava/util/List;
+	public abstract fun getCountryCode ()Lcom/algolia/search/model/places/Country;
+	public abstract fun getCountryCodeOrNull ()Lcom/algolia/search/model/places/Country;
+	public abstract fun getDistrict ()Ljava/lang/String;
+	public abstract fun getDistrictOrNull ()Ljava/lang/String;
+	public abstract fun getGeolocation ()Ljava/util/List;
+	public abstract fun getGeolocationOrNull ()Ljava/util/List;
+	public abstract fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public abstract fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public abstract fun getImportance ()I
+	public abstract fun getImportanceOrNull ()Ljava/lang/Integer;
+	public abstract fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public abstract fun getObjectIDOrNull ()Lcom/algolia/search/model/ObjectID;
+	public abstract fun getPopulation ()J
+	public abstract fun getPopulationOrNull ()Ljava/lang/Long;
+	public abstract fun getPostCode ()Ljava/util/List;
+	public abstract fun getPostCodeOrNull ()Ljava/util/List;
+	public abstract fun getRankingInfo ()Lcom/algolia/search/model/search/RankingInfo;
+	public abstract fun getRankingInfoOrNull ()Lcom/algolia/search/model/search/RankingInfo;
+	public abstract fun getSuburb ()Ljava/util/List;
+	public abstract fun getSuburbOrNull ()Ljava/util/List;
+	public abstract fun getTags ()Ljava/util/List;
+	public abstract fun getTagsOrNull ()Ljava/util/List;
+	public abstract fun getVillage ()Ljava/util/List;
+	public abstract fun getVillageOrNull ()Ljava/util/List;
+	public abstract fun isCity ()Z
+	public abstract fun isCityOrNull ()Ljava/lang/Boolean;
+	public abstract fun isCountry ()Z
+	public abstract fun isCountryOrNull ()Ljava/lang/Boolean;
+	public abstract fun isHighway ()Z
+	public abstract fun isHighwayOrNull ()Ljava/lang/Boolean;
+	public abstract fun isPopular ()Z
+	public abstract fun isPopularOrNull ()Ljava/lang/Boolean;
+	public abstract fun isSuburb ()Z
+	public abstract fun isSuburbOrNull ()Ljava/lang/Boolean;
+}
+
+public final class com/algolia/search/model/places/Place$DefaultImpls {
+	public static fun getAdminLevel (Lcom/algolia/search/model/places/Place;)I
+	public static fun getAdministrative (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun getCountryCode (Lcom/algolia/search/model/places/Place;)Lcom/algolia/search/model/places/Country;
+	public static fun getDistrict (Lcom/algolia/search/model/places/Place;)Ljava/lang/String;
+	public static fun getGeolocation (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun getHighlightResult (Lcom/algolia/search/model/places/Place;)Lkotlinx/serialization/json/JsonObject;
+	public static fun getImportance (Lcom/algolia/search/model/places/Place;)I
+	public static fun getObjectID (Lcom/algolia/search/model/places/Place;)Lcom/algolia/search/model/ObjectID;
+	public static fun getPopulation (Lcom/algolia/search/model/places/Place;)J
+	public static fun getPostCode (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun getRankingInfo (Lcom/algolia/search/model/places/Place;)Lcom/algolia/search/model/search/RankingInfo;
+	public static fun getSuburb (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun getTags (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun getVillage (Lcom/algolia/search/model/places/Place;)Ljava/util/List;
+	public static fun isCity (Lcom/algolia/search/model/places/Place;)Z
+	public static fun isCountry (Lcom/algolia/search/model/places/Place;)Z
+	public static fun isHighway (Lcom/algolia/search/model/places/Place;)Z
+	public static fun isPopular (Lcom/algolia/search/model/places/Place;)Z
+	public static fun isSuburb (Lcom/algolia/search/model/places/Place;)Z
+}
+
+public final class com/algolia/search/model/places/PlaceLanguage : com/algolia/search/model/places/Place {
+	public static final field Companion Lcom/algolia/search/model/places/PlaceLanguage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/lang/Boolean;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/lang/Boolean;
+	public final fun component23 ()Lcom/algolia/search/model/search/RankingInfo;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lcom/algolia/search/model/places/Country;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;)Lcom/algolia/search/model/places/PlaceLanguage;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/places/PlaceLanguage;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;ILjava/lang/Object;)Lcom/algolia/search/model/places/PlaceLanguage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdminLevel ()I
+	public fun getAdminLevelOrNull ()Ljava/lang/Integer;
+	public fun getAdministrative ()Ljava/util/List;
+	public fun getAdministrativeOrNull ()Ljava/util/List;
+	public final fun getCity ()Ljava/util/List;
+	public final fun getCityOrNull ()Ljava/util/List;
+	public final fun getCountry ()Ljava/lang/String;
+	public fun getCountryCode ()Lcom/algolia/search/model/places/Country;
+	public fun getCountryCodeOrNull ()Lcom/algolia/search/model/places/Country;
+	public final fun getCountryOrNull ()Ljava/lang/String;
+	public final fun getCounty ()Ljava/util/List;
+	public final fun getCountyOrNull ()Ljava/util/List;
+	public fun getDistrict ()Ljava/lang/String;
+	public fun getDistrictOrNull ()Ljava/lang/String;
+	public fun getGeolocation ()Ljava/util/List;
+	public fun getGeolocationOrNull ()Ljava/util/List;
+	public fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public fun getImportance ()I
+	public fun getImportanceOrNull ()Ljava/lang/Integer;
+	public final fun getLocalNames ()Ljava/util/List;
+	public final fun getLocalNamesOrNull ()Ljava/util/List;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getObjectIDOrNull ()Lcom/algolia/search/model/ObjectID;
+	public fun getPopulation ()J
+	public fun getPopulationOrNull ()Ljava/lang/Long;
+	public fun getPostCode ()Ljava/util/List;
+	public fun getPostCodeOrNull ()Ljava/util/List;
+	public fun getRankingInfo ()Lcom/algolia/search/model/search/RankingInfo;
+	public fun getRankingInfoOrNull ()Lcom/algolia/search/model/search/RankingInfo;
+	public fun getSuburb ()Ljava/util/List;
+	public fun getSuburbOrNull ()Ljava/util/List;
+	public fun getTags ()Ljava/util/List;
+	public fun getTagsOrNull ()Ljava/util/List;
+	public fun getVillage ()Ljava/util/List;
+	public fun getVillageOrNull ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun isCity ()Z
+	public fun isCityOrNull ()Ljava/lang/Boolean;
+	public fun isCountry ()Z
+	public fun isCountryOrNull ()Ljava/lang/Boolean;
+	public fun isHighway ()Z
+	public fun isHighwayOrNull ()Ljava/lang/Boolean;
+	public fun isPopular ()Z
+	public fun isPopularOrNull ()Ljava/lang/Boolean;
+	public fun isSuburb ()Z
+	public fun isSuburbOrNull ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/places/PlaceLanguage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/places/PlaceLanguage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceLanguage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/places/PlaceLanguage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/places/PlaceLanguage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/PlaceLanguage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/PlaceLanguages : com/algolia/search/model/places/Place {
+	public static final field Companion Lcom/algolia/search/model/places/PlaceLanguages$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/lang/Boolean;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/lang/Boolean;
+	public final fun component23 ()Lcom/algolia/search/model/search/RankingInfo;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lcom/algolia/search/model/places/Country;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;)Lcom/algolia/search/model/places/PlaceLanguages;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/places/PlaceLanguages;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/places/Country;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/algolia/search/model/search/RankingInfo;ILjava/lang/Object;)Lcom/algolia/search/model/places/PlaceLanguages;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdminLevel ()I
+	public fun getAdminLevelOrNull ()Ljava/lang/Integer;
+	public fun getAdministrative ()Ljava/util/List;
+	public fun getAdministrativeOrNull ()Ljava/util/List;
+	public final fun getCity ()Ljava/util/Map;
+	public final fun getCityOrNull ()Ljava/util/Map;
+	public final fun getCountry ()Ljava/util/Map;
+	public fun getCountryCode ()Lcom/algolia/search/model/places/Country;
+	public fun getCountryCodeOrNull ()Lcom/algolia/search/model/places/Country;
+	public final fun getCountryOrNull ()Ljava/util/Map;
+	public final fun getCounty ()Ljava/util/Map;
+	public final fun getCountyOrNull ()Ljava/util/Map;
+	public fun getDistrict ()Ljava/lang/String;
+	public fun getDistrictOrNull ()Ljava/lang/String;
+	public fun getGeolocation ()Ljava/util/List;
+	public fun getGeolocationOrNull ()Ljava/util/List;
+	public fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public fun getImportance ()I
+	public fun getImportanceOrNull ()Ljava/lang/Integer;
+	public final fun getLocalNames ()Ljava/util/Map;
+	public final fun getLocalNamesOrNull ()Ljava/util/Map;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getObjectIDOrNull ()Lcom/algolia/search/model/ObjectID;
+	public fun getPopulation ()J
+	public fun getPopulationOrNull ()Ljava/lang/Long;
+	public fun getPostCode ()Ljava/util/List;
+	public fun getPostCodeOrNull ()Ljava/util/List;
+	public fun getRankingInfo ()Lcom/algolia/search/model/search/RankingInfo;
+	public fun getRankingInfoOrNull ()Lcom/algolia/search/model/search/RankingInfo;
+	public fun getSuburb ()Ljava/util/List;
+	public fun getSuburbOrNull ()Ljava/util/List;
+	public fun getTags ()Ljava/util/List;
+	public fun getTagsOrNull ()Ljava/util/List;
+	public fun getVillage ()Ljava/util/List;
+	public fun getVillageOrNull ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun isCity ()Z
+	public fun isCityOrNull ()Ljava/lang/Boolean;
+	public fun isCountry ()Z
+	public fun isCountryOrNull ()Ljava/lang/Boolean;
+	public fun isHighway ()Z
+	public fun isHighwayOrNull ()Ljava/lang/Boolean;
+	public fun isPopular ()Z
+	public fun isPopularOrNull ()Ljava/lang/Boolean;
+	public fun isSuburb ()Z
+	public fun isSuburbOrNull ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/places/PlaceLanguages;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/places/PlaceLanguages$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceLanguages$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/places/PlaceLanguages;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/places/PlaceLanguages;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/PlaceLanguages$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/places/PlaceType : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/places/PlaceType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/places/PlaceType$Address : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$Address;
+}
+
+public final class com/algolia/search/model/places/PlaceType$Airport : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$Airport;
+}
+
+public final class com/algolia/search/model/places/PlaceType$BusStop : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$BusStop;
+}
+
+public final class com/algolia/search/model/places/PlaceType$City : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$City;
+}
+
+public final class com/algolia/search/model/places/PlaceType$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/places/PlaceType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/places/PlaceType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/PlaceType$Country : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$Country;
+}
+
+public final class com/algolia/search/model/places/PlaceType$Other : com/algolia/search/model/places/PlaceType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/places/PlaceType$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/places/PlaceType$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/places/PlaceType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/places/PlaceType$TownHall : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$TownHall;
+}
+
+public final class com/algolia/search/model/places/PlaceType$TrainStation : com/algolia/search/model/places/PlaceType {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlaceType$TrainStation;
+}
+
+public final class com/algolia/search/model/places/PlacesQuery {
+	public static final field Companion Lcom/algolia/search/model/places/PlacesQuery$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lcom/algolia/search/model/places/PlaceType;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/search/Language;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/places/PlaceType;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Ljava/lang/Boolean;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/algolia/search/model/places/PlaceType;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Ljava/lang/Boolean;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/places/PlaceType;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lcom/algolia/search/model/search/Point;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/places/PlaceType;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Ljava/lang/Boolean;Ljava/lang/Integer;)Lcom/algolia/search/model/places/PlacesQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/places/PlacesQuery;Ljava/lang/String;Lcom/algolia/search/model/places/PlaceType;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/algolia/search/model/places/PlacesQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public final fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public final fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun getCountries ()Ljava/util/List;
+	public final fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public final fun getHitsPerPage ()Ljava/lang/Integer;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getType ()Lcom/algolia/search/model/places/PlaceType;
+	public fun hashCode ()I
+	public final fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public final fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public final fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public final fun setCountries (Ljava/util/List;)V
+	public final fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public final fun setHitsPerPage (Ljava/lang/Integer;)V
+	public final fun setQuery (Ljava/lang/String;)V
+	public final fun setType (Lcom/algolia/search/model/places/PlaceType;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/places/PlacesQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/places/PlacesQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/places/PlacesQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/places/PlacesQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/places/PlacesQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/places/PlacesQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery : com/algolia/search/model/recommend/RecommendationsOptions {
+	public static final field Companion Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun component6 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;)Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILjava/lang/Object;)Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFallbackParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getMaxRecommendations ()Ljava/lang/Integer;
+	public fun getModel-PpxrRy8 ()Ljava/lang/String;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getQueryParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getThreshold ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/FrequentlyBoughtTogetherQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/RecommendationModel {
+	public static final field Companion Lcom/algolia/search/model/recommend/RecommendationModel$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/algolia/search/model/recommend/RecommendationModel;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getModel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/recommend/RecommendationModel$Companion {
+	public final fun getBoughtTogether-PpxrRy8 ()Ljava/lang/String;
+	public final fun getRelatedProducts-PpxrRy8 ()Ljava/lang/String;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/recommend/RecommendationsOptions {
+	public abstract fun getFallbackParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public abstract fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public abstract fun getMaxRecommendations ()Ljava/lang/Integer;
+	public abstract fun getModel-PpxrRy8 ()Ljava/lang/String;
+	public abstract fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public abstract fun getQueryParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public abstract fun getThreshold ()Ljava/lang/Integer;
+}
+
+public final class com/algolia/search/model/recommend/RecommendationsQuery : com/algolia/search/model/recommend/RecommendationsOptions {
+	public static final field Companion Lcom/algolia/search/model/recommend/RecommendationsQuery$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Ljava/lang/String;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Ljava/lang/String;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Ljava/lang/String;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2-PpxrRy8 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun component7 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun copy-SOiUBEg (Lcom/algolia/search/model/IndexName;Ljava/lang/String;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;)Lcom/algolia/search/model/recommend/RecommendationsQuery;
+	public static synthetic fun copy-SOiUBEg$default (Lcom/algolia/search/model/recommend/RecommendationsQuery;Lcom/algolia/search/model/IndexName;Ljava/lang/String;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILjava/lang/Object;)Lcom/algolia/search/model/recommend/RecommendationsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFallbackParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getMaxRecommendations ()Ljava/lang/Integer;
+	public fun getModel-PpxrRy8 ()Ljava/lang/String;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getQueryParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getThreshold ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/recommend/RecommendationsQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/recommend/RecommendationsQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/recommend/RecommendationsQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/recommend/RecommendationsQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/recommend/RecommendationsQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/RecommendationsQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/RelatedProductsQuery : com/algolia/search/model/recommend/RecommendationsOptions {
+	public static final field Companion Lcom/algolia/search/model/recommend/RelatedProductsQuery$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun component6 ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;)Lcom/algolia/search/model/recommend/RelatedProductsQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/recommend/RelatedProductsQuery;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ObjectID;ILjava/lang/Integer;Lcom/algolia/search/model/search/RecommendSearchOptions;Lcom/algolia/search/model/search/RecommendSearchOptions;ILjava/lang/Object;)Lcom/algolia/search/model/recommend/RelatedProductsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFallbackParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getMaxRecommendations ()Ljava/lang/Integer;
+	public fun getModel-PpxrRy8 ()Ljava/lang/String;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getQueryParameters ()Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun getThreshold ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/recommend/RelatedProductsQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/recommend/RelatedProductsQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/recommend/RelatedProductsQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/recommend/RelatedProductsQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/recommend/RelatedProductsQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/recommend/RelatedProductsQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseABTest {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseABTest$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Lcom/algolia/search/model/analytics/ABTestStatus;Lcom/algolia/search/model/response/ResponseVariant;Lcom/algolia/search/model/response/ResponseVariant;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Lcom/algolia/search/model/analytics/ABTestStatus;Lcom/algolia/search/model/response/ResponseVariant;Lcom/algolia/search/model/response/ResponseVariant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/algolia/search/model/analytics/ABTestStatus;
+	public final fun component8 ()Lcom/algolia/search/model/response/ResponseVariant;
+	public final fun component9 ()Lcom/algolia/search/model/response/ResponseVariant;
+	public final fun copy (Lcom/algolia/search/model/analytics/ABTestID;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Lcom/algolia/search/model/analytics/ABTestStatus;Lcom/algolia/search/model/response/ResponseVariant;Lcom/algolia/search/model/response/ResponseVariant;)Lcom/algolia/search/model/response/ResponseABTest;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseABTest;Lcom/algolia/search/model/analytics/ABTestID;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Lcom/algolia/search/model/analytics/ABTestStatus;Lcom/algolia/search/model/response/ResponseVariant;Lcom/algolia/search/model/response/ResponseVariant;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseABTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestID ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getClickSignificance ()F
+	public final fun getClickSignificanceOrNull ()Ljava/lang/Float;
+	public final fun getConversionSignificance ()F
+	public final fun getConversionSignificanceOrNull ()Ljava/lang/Float;
+	public final fun getCreatedAt ()Ljava/lang/String;
+	public final fun getEndAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Lcom/algolia/search/model/analytics/ABTestStatus;
+	public final fun getVariantA ()Lcom/algolia/search/model/response/ResponseVariant;
+	public final fun getVariantB ()Lcom/algolia/search/model/response/ResponseVariant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseABTest$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseABTest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseABTest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseABTestShort {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseABTestShort$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;)V
+	public final fun component1 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component2 ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun component3 ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun copy (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;)Lcom/algolia/search/model/response/ResponseABTestShort;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseABTestShort;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/analytics/Variant;Lcom/algolia/search/model/analytics/Variant;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseABTestShort;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestId ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getVariantA ()Lcom/algolia/search/model/analytics/Variant;
+	public final fun getVariantB ()Lcom/algolia/search/model/analytics/Variant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseABTestShort$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseABTestShort;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseABTestShort;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseABTests {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseABTests$Companion;
+	public synthetic fun <init> (IIILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (IILjava/util/List;)V
+	public synthetic fun <init> (IILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (IILjava/util/List;)Lcom/algolia/search/model/response/ResponseABTests;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseABTests;IILjava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseABTests;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTests ()Ljava/util/List;
+	public final fun getAbTestsOrNull ()Ljava/util/List;
+	public final fun getCount ()I
+	public final fun getTotal ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseABTests;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseABTests$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseABTests$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseABTests;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseABTests;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseABTests$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseAPIKey {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseAPIKey$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Ljava/util/List;JLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Ljava/util/List;JLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Ljava/util/List;JLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/APIKey;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Ljava/util/List;JLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;)Lcom/algolia/search/model/response/ResponseAPIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Ljava/util/List;JLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseAPIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getACLs ()Ljava/util/List;
+	public final fun getApiKey ()Lcom/algolia/search/model/APIKey;
+	public final fun getCreatedAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getCreatedAtOrNull ()Lcom/algolia/search/model/ClientDate;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDescriptionOrNull ()Ljava/lang/String;
+	public final fun getIndices ()Ljava/util/List;
+	public final fun getIndicesOrNull ()Ljava/util/List;
+	public final fun getMaxHitsPerQuery ()I
+	public final fun getMaxHitsPerQueryOrNull ()Ljava/lang/Integer;
+	public final fun getMaxQueriesPerIPPerHour ()I
+	public final fun getMaxQueriesPerIPPerHourOrNull ()Ljava/lang/Integer;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getQueryOrNull ()Ljava/lang/String;
+	public final fun getReferers ()Ljava/util/List;
+	public final fun getReferersOrNull ()Ljava/util/List;
+	public final fun getValidity ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseAPIKey;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseAPIKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseAPIKey$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseAPIKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseAPIKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseAPIKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseBatch : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseBatch$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/task/TaskID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/task/TaskID;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/task/TaskID;Ljava/util/List;)Lcom/algolia/search/model/response/ResponseBatch;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseBatch;Lcom/algolia/search/model/task/TaskID;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseBatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectIDs ()Ljava/util/List;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseBatch;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseBatch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseBatch$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseBatch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseBatch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseBatch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseBatches {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseBatches$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/algolia/search/model/response/ResponseBatches;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseBatches;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseBatches;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectIDs ()Ljava/util/List;
+	public final fun getObjectIDsOrNull ()Ljava/util/List;
+	public final fun getTasks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseBatches$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseBatches;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseBatches;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseDictionary : com/algolia/search/model/task/DictionaryTask {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseDictionary$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/DictionaryTaskID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/DictionaryTaskID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/DictionaryTaskID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/DictionaryTaskID;)Lcom/algolia/search/model/response/ResponseDictionary;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseDictionary;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/DictionaryTaskID;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseDictionary;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTaskID ()Lcom/algolia/search/model/task/DictionaryTaskID;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseDictionary;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseDictionary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseDictionary$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseDictionary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseDictionary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseDictionary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseHasPendingMapping {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseHasPendingMapping$Companion;
+	public synthetic fun <init> (IZLjava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLjava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/Map;)Lcom/algolia/search/model/response/ResponseHasPendingMapping;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseHasPendingMapping;ZLjava/util/Map;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseHasPendingMapping;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClusters ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun isPending ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseHasPendingMapping;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseHasPendingMapping$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseHasPendingMapping$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseHasPendingMapping;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseHasPendingMapping;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseHasPendingMapping$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseHitWithPosition {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseHitWithPosition$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/response/ResponseSearch$Hit;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/response/ResponseSearch$Hit;II)V
+	public final fun component1 ()Lcom/algolia/search/model/response/ResponseSearch$Hit;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Lcom/algolia/search/model/response/ResponseSearch$Hit;II)Lcom/algolia/search/model/response/ResponseHitWithPosition;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseHitWithPosition;Lcom/algolia/search/model/response/ResponseSearch$Hit;IIILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseHitWithPosition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHit ()Lcom/algolia/search/model/response/ResponseSearch$Hit;
+	public final fun getPage ()I
+	public final fun getPosition ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseHitWithPosition;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseHitWithPosition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseHitWithPosition$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseHitWithPosition;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseHitWithPosition;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseHitWithPosition$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListAPIKey {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListAPIKey$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/response/ResponseListAPIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListAPIKey;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListAPIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListAPIKey;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListAPIKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListAPIKey$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListAPIKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListAPIKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListAPIKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListClusters$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/response/ResponseListClusters;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListClusters;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListClusters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClusters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListClusters;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListClusters$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListClusters;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListClusters;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters$Cluster {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListClusters$Cluster$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/multicluster/ClusterName;IJJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/multicluster/ClusterName;IJJ)V
+	public final fun component1 ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (Lcom/algolia/search/model/multicluster/ClusterName;IJJ)Lcom/algolia/search/model/response/ResponseListClusters$Cluster;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListClusters$Cluster;Lcom/algolia/search/model/multicluster/ClusterName;IJJILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListClusters$Cluster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSize ()J
+	public final fun getName ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun getNbRecords ()I
+	public final fun getNbUserIDs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListClusters$Cluster;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters$Cluster$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListClusters$Cluster$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListClusters$Cluster;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListClusters$Cluster;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters$Cluster$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListClusters$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListIndices$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/List;I)Lcom/algolia/search/model/response/ResponseListIndices;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListIndices;Ljava/util/List;IILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListIndices;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getNbPages ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListIndices;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListIndices$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListIndices;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListIndices;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices$Item {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListIndices$Item$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ClientDate;IJJIIZLjava/util/List;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/response/ResponseABTestShort;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ClientDate;IJJIIZLjava/util/List;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/response/ResponseABTestShort;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ClientDate;IJJIIZLjava/util/List;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/response/ResponseABTestShort;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Lcom/algolia/search/model/IndexName;
+	public final fun component12 ()Lcom/algolia/search/model/IndexName;
+	public final fun component13 ()Lcom/algolia/search/model/response/ResponseABTestShort;
+	public final fun component2 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component3 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component4 ()I
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()Z
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ClientDate;IJJIIZLjava/util/List;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/response/ResponseABTestShort;)Lcom/algolia/search/model/response/ResponseListIndices$Item;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListIndices$Item;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ClientDate;IJJIIZLjava/util/List;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/response/ResponseABTestShort;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListIndices$Item;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTest ()Lcom/algolia/search/model/response/ResponseABTestShort;
+	public final fun getAbTestOrNull ()Lcom/algolia/search/model/response/ResponseABTestShort;
+	public final fun getCreatedAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getDataSize ()J
+	public final fun getEntries ()I
+	public final fun getFileSize ()J
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getLastBuildTimeS ()I
+	public final fun getNumberOfPendingTasks ()I
+	public final fun getPendingTask ()Z
+	public final fun getPrimary ()Lcom/algolia/search/model/IndexName;
+	public final fun getPrimaryOrNull ()Lcom/algolia/search/model/IndexName;
+	public final fun getReplicas ()Ljava/util/List;
+	public final fun getReplicasOrNull ()Ljava/util/List;
+	public final fun getSourceABTest ()Lcom/algolia/search/model/IndexName;
+	public final fun getSourceABTestOrNull ()Lcom/algolia/search/model/IndexName;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListIndices$Item;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices$Item$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListIndices$Item$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListIndices$Item;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListIndices$Item;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListIndices$Item$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListUserIDs {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseListUserIDs$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lcom/algolia/search/model/response/ResponseListUserIDs;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseListUserIDs;Ljava/util/List;IIILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseListUserIDs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHitsPerPageOrNull ()I
+	public final fun getPageOrNull ()I
+	public final fun getUserIDs ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseListUserIDs;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseListUserIDs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseListUserIDs$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseListUserIDs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseListUserIDs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseListUserIDs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseLogs$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/response/ResponseLogs;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseLogs;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseLogs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLogs ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseLogs;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseLogs$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseLogs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseLogs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseLogs$Log$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JLjava/lang/Integer;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JLjava/lang/Integer;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JLjava/lang/Integer;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()J
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Lcom/algolia/search/model/IndexName;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JLjava/lang/Integer;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;)Lcom/algolia/search/model/response/ResponseLogs$Log;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseLogs$Log;Lcom/algolia/search/model/ClientDate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JLjava/lang/Integer;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseLogs$Log;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnswer ()Ljava/lang/String;
+	public final fun getAnswerCode ()Ljava/lang/String;
+	public final fun getExhaustiveFaceting ()Ljava/lang/Boolean;
+	public final fun getExhaustiveNbHits ()Ljava/lang/Boolean;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getIndexNameOrNull ()Lcom/algolia/search/model/IndexName;
+	public final fun getInnerQueries ()Ljava/util/List;
+	public final fun getIp ()Ljava/lang/String;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getNbApiCalls ()J
+	public final fun getNbApiCallsOrNull ()Ljava/lang/Long;
+	public final fun getProcessingTimeMS ()J
+	public final fun getQueryBody ()Ljava/lang/String;
+	public final fun getQueryHeaders ()Ljava/lang/String;
+	public final fun getQueryNbHits ()I
+	public final fun getQueryNbHitsOrNull ()Ljava/lang/Integer;
+	public final fun getQueryParams ()Ljava/lang/String;
+	public final fun getQueryParamsOrNull ()Ljava/lang/String;
+	public final fun getSha1 ()Ljava/lang/String;
+	public final fun getTimestamp ()Lcom/algolia/search/model/ClientDate;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseLogs$Log;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseLogs$Log$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseLogs$Log;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseLogs$Log;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log$InnerQuery {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/QueryID;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/QueryID;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/QueryID;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/QueryID;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/QueryID;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;)Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/QueryID;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getOffset ()Ljava/lang/Integer;
+	public final fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public final fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log$InnerQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseLogs$Log$InnerQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseLogs$Log$InnerQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseMultiSearch {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseMultiSearch$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/response/ResponseMultiSearch;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseMultiSearch;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseMultiSearch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseMultiSearch;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseMultiSearch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseMultiSearch$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseMultiSearch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseMultiSearch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseMultiSearch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseObjects {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseObjects$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lcom/algolia/search/model/response/ResponseObjects;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseObjects;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseObjects;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getMessageOrNull ()Ljava/lang/String;
+	public final fun getResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseObjects;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseObjects$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseObjects$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseObjects;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseObjects;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseObjects$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch : com/algolia/search/model/response/ResultSearch {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearch$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (IILjava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/algolia/search/model/search/Point;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/IndexName;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Lcom/algolia/search/model/QueryID;Ljava/util/Map;Lcom/algolia/search/model/search/Explain;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/analytics/ABTestID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/algolia/search/model/search/Point;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/IndexName;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Lcom/algolia/search/model/QueryID;Ljava/util/Map;Lcom/algolia/search/model/search/Explain;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/analytics/ABTestID;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/algolia/search/model/search/Point;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/IndexName;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Lcom/algolia/search/model/QueryID;Ljava/util/Map;Lcom/algolia/search/model/search/Explain;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/analytics/ABTestID;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Lcom/algolia/search/model/search/Point;
+	public final fun component17 ()Ljava/lang/Float;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()Ljava/util/Map;
+	public final fun component24 ()Ljava/util/Map;
+	public final fun component25 ()Lcom/algolia/search/model/search/Cursor;
+	public final fun component26 ()Lcom/algolia/search/model/IndexName;
+	public final fun component27 ()Ljava/lang/Boolean;
+	public final fun component28 ()Lcom/algolia/search/model/QueryID;
+	public final fun component29 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component30 ()Lcom/algolia/search/model/search/Explain;
+	public final fun component31 ()Ljava/util/List;
+	public final fun component32 ()Ljava/lang/Integer;
+	public final fun component33 ()Ljava/lang/Integer;
+	public final fun component34 ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun component35 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/algolia/search/model/search/Point;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/IndexName;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Lcom/algolia/search/model/QueryID;Ljava/util/Map;Lcom/algolia/search/model/search/Explain;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/analytics/ABTestID;)Lcom/algolia/search/model/response/ResponseSearch;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearch;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/algolia/search/model/search/Point;Ljava/lang/Float;Ljava/lang/String;Lcom/algolia/search/model/IndexName;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lcom/algolia/search/model/search/Cursor;Lcom/algolia/search/model/IndexName;Ljava/lang/Boolean;Lcom/algolia/search/model/QueryID;Ljava/util/Map;Lcom/algolia/search/model/search/Explain;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/analytics/ABTestID;IILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestID ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getAbTestIDOrNull ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getAbTestVariantID ()I
+	public final fun getAbTestVariantIDOrNull ()Ljava/lang/Integer;
+	public final fun getAppliedRelevancyStrictness ()I
+	public final fun getAppliedRelevancyStrictnessOrNull ()Ljava/lang/Integer;
+	public final fun getAppliedRules ()Ljava/util/List;
+	public final fun getAppliedRulesOrNull ()Ljava/util/List;
+	public final fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public final fun getAroundLatLngOrNull ()Lcom/algolia/search/model/search/Point;
+	public final fun getAutomaticRadius ()F
+	public final fun getAutomaticRadiusOrNull ()Ljava/lang/Float;
+	public final fun getCursor ()Lcom/algolia/search/model/search/Cursor;
+	public final fun getCursorOrNull ()Lcom/algolia/search/model/search/Cursor;
+	public final fun getDisjunctiveFacets ()Ljava/util/Map;
+	public final fun getDisjunctiveFacetsOrNull ()Ljava/util/Map;
+	public final fun getExhaustiveFacetsCount ()Z
+	public final fun getExhaustiveFacetsCountOrNull ()Ljava/lang/Boolean;
+	public final fun getExhaustiveNbHits ()Z
+	public final fun getExhaustiveNbHitsOrNull ()Ljava/lang/Boolean;
+	public final fun getExplain ()Lcom/algolia/search/model/search/Explain;
+	public final fun getExplainOrNull ()Lcom/algolia/search/model/search/Explain;
+	public final fun getFacetStats ()Ljava/util/Map;
+	public final fun getFacetStatsOrNull ()Ljava/util/Map;
+	public final fun getFacets ()Ljava/util/Map;
+	public final fun getFacetsOrNull ()Ljava/util/Map;
+	public final fun getHierarchicalFacets ()Ljava/util/Map;
+	public final fun getHierarchicalFacetsOrNull ()Ljava/util/Map;
+	public final fun getHits ()Ljava/util/List;
+	public final fun getHitsOrNull ()Ljava/util/List;
+	public final fun getHitsPerPage ()I
+	public final fun getHitsPerPageOrNull ()Ljava/lang/Integer;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getIndexNameOrNull ()Lcom/algolia/search/model/IndexName;
+	public final fun getIndexUsed ()Lcom/algolia/search/model/IndexName;
+	public final fun getIndexUsedOrNull ()Lcom/algolia/search/model/IndexName;
+	public final fun getLength ()I
+	public final fun getLengthOrNull ()Ljava/lang/Integer;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getMessageOrNull ()Ljava/lang/String;
+	public final fun getNbHits ()I
+	public final fun getNbHitsOrNull ()Ljava/lang/Integer;
+	public final fun getNbPages ()I
+	public final fun getNbPagesOrNull ()Ljava/lang/Integer;
+	public final fun getNbSortedHits ()I
+	public final fun getNbSortedHitsOrNull ()Ljava/lang/Integer;
+	public final fun getObjectPosition (Lcom/algolia/search/model/ObjectID;)I
+	public final fun getOffset ()I
+	public final fun getOffsetOrNull ()Ljava/lang/Integer;
+	public final fun getPage ()I
+	public final fun getPageOrNull ()Ljava/lang/Integer;
+	public final fun getParams ()Ljava/lang/String;
+	public final fun getParamsOrNull ()Ljava/lang/String;
+	public final fun getParsedQuery ()Ljava/lang/String;
+	public final fun getParsedQueryOrNull ()Ljava/lang/String;
+	public final fun getProcessed ()Z
+	public final fun getProcessedOrNull ()Ljava/lang/Boolean;
+	public final fun getProcessingTimeMS ()J
+	public final fun getProcessingTimeMSOrNull ()Ljava/lang/Long;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getQueryAfterRemoval ()Ljava/lang/String;
+	public final fun getQueryAfterRemovalOrNull ()Ljava/lang/String;
+	public final fun getQueryID ()Lcom/algolia/search/model/QueryID;
+	public final fun getQueryIDOrNull ()Lcom/algolia/search/model/QueryID;
+	public final fun getQueryOrNull ()Ljava/lang/String;
+	public final fun getRenderingContent ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun getRenderingContentOrNull ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun getServerUsed ()Ljava/lang/String;
+	public final fun getServerUsedOrNull ()Ljava/lang/String;
+	public final fun getUserData ()Ljava/util/List;
+	public final fun getUserDataOrNull ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearch;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearch$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Answer {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearch$Answer$Companion;
+	public synthetic fun <init> (ILjava/lang/String;DLcom/algolia/search/model/Attribute;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;DLcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Ljava/lang/String;DLcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/response/ResponseSearch$Answer;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearch$Answer;Ljava/lang/String;DLcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearch$Answer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtract ()Ljava/lang/String;
+	public final fun getExtractAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getScore ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearch$Answer;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Answer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearch$Answer$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearch$Answer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearch$Answer;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Answer$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Hit : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearch$Hit$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
+	public fun clear ()V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
+	public synthetic fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun compute (Ljava/lang/String;Ljava/util/function/BiFunction;)Lkotlinx/serialization/json/JsonElement;
+	public synthetic fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/String;Ljava/util/function/Function;)Lkotlinx/serialization/json/JsonElement;
+	public synthetic fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/String;Ljava/util/function/BiFunction;)Lkotlinx/serialization/json/JsonElement;
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public fun containsValue (Lkotlinx/serialization/json/JsonElement;)Z
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/response/ResponseSearch$Hit;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearch$Hit;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearch$Hit;
+	public final fun deserialize (Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
+	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+	public fun get (Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
+	public final fun getAnswer ()Lcom/algolia/search/model/response/ResponseSearch$Answer;
+	public final fun getAnswerOrNull ()Lcom/algolia/search/model/response/ResponseSearch$Answer;
+	public final fun getDistinctSeqID ()I
+	public final fun getDistinctSeqIDOrNull ()Ljava/lang/Integer;
+	public fun getEntries ()Ljava/util/Set;
+	public final fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getKeys ()Ljava/util/Set;
+	public final fun getRankingInfo ()Lcom/algolia/search/model/search/RankingInfo;
+	public final fun getRankingInfoOrNull ()Lcom/algolia/search/model/search/RankingInfo;
+	public final fun getScore ()F
+	public final fun getScoreOrNull ()Ljava/lang/Float;
+	public fun getSize ()I
+	public final fun getSnippetResult ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSnippetResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getValue (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/Attribute;)Ljava/lang/Object;
+	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun merge (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/util/function/BiFunction;)Lkotlinx/serialization/json/JsonElement;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
+	public fun putAll (Ljava/util/Map;)V
+	public synthetic fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putIfAbsent (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
+	public fun replace (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class com/algolia/search/model/response/ResponseSearch$Hit$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearch$Hit;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearch$Hit;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchDictionaries {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchDictionaries$Companion;
+	public synthetic fun <init> (ILjava/util/List;IIILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;III)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (Ljava/util/List;III)Lcom/algolia/search/model/response/ResponseSearchDictionaries;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchDictionaries;Ljava/util/List;IIIILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchDictionaries;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHits ()Ljava/util/List;
+	public final fun getNbHits ()I
+	public final fun getNbPages ()I
+	public final fun getPage ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchDictionaries;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlinx/serialization/KSerializer;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchDictionaries$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchDictionaries;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchDictionaries;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchDictionaries$Companion {
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchForFacets : com/algolia/search/model/response/ResultSearch {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchForFacets$Companion;
+	public synthetic fun <init> (ILjava/util/List;ZJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ZJ)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()J
+	public final fun copy (Ljava/util/List;ZJ)Lcom/algolia/search/model/response/ResponseSearchForFacets;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchForFacets;Ljava/util/List;ZJILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchForFacets;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExhaustiveFacetsCount ()Z
+	public final fun getFacets ()Ljava/util/List;
+	public final fun getProcessingTimeMS ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchForFacets;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchForFacets$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchForFacets$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchForFacets;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchForFacets;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchForFacets$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/response/ResponseSearchPlaces {
+	public abstract fun getDegradedQuery ()Ljava/lang/String;
+	public abstract fun getDegradedQueryOrNull ()Ljava/lang/String;
+	public abstract fun getHits ()Ljava/util/List;
+	public abstract fun getNbHits ()I
+	public abstract fun getParams ()Ljava/lang/String;
+	public abstract fun getParsedQuery ()Ljava/lang/String;
+	public abstract fun getParsedQueryOrNull ()Ljava/lang/String;
+	public abstract fun getProcessingTimeMS ()J
+	public abstract fun getQuery ()Ljava/lang/String;
+	public abstract fun getQueryOrNull ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlaces$DefaultImpls {
+	public static fun getDegradedQuery (Lcom/algolia/search/model/response/ResponseSearchPlaces;)Ljava/lang/String;
+	public static fun getParsedQuery (Lcom/algolia/search/model/response/ResponseSearchPlaces;)Ljava/lang/String;
+	public static fun getQuery (Lcom/algolia/search/model/response/ResponseSearchPlaces;)Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMono : com/algolia/search/model/response/ResponseSearchPlaces {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchPlacesMono$Companion;
+	public synthetic fun <init> (ILjava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/algolia/search/model/response/ResponseSearchPlacesMono;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchPlacesMono;Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchPlacesMono;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDegradedQuery ()Ljava/lang/String;
+	public fun getDegradedQueryOrNull ()Ljava/lang/String;
+	public fun getHits ()Ljava/util/List;
+	public fun getNbHits ()I
+	public fun getParams ()Ljava/lang/String;
+	public fun getParsedQuery ()Ljava/lang/String;
+	public fun getParsedQueryOrNull ()Ljava/lang/String;
+	public fun getProcessingTimeMS ()J
+	public fun getQuery ()Ljava/lang/String;
+	public fun getQueryOrNull ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchPlacesMono;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMono$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchPlacesMono$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchPlacesMono;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchPlacesMono;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMono$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMulti : com/algolia/search/model/response/ResponseSearchPlaces {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchPlacesMulti$Companion;
+	public synthetic fun <init> (ILjava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;Ljava/util/List;IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDegradedQuery ()Ljava/lang/String;
+	public fun getDegradedQueryOrNull ()Ljava/lang/String;
+	public fun getHits ()Ljava/util/List;
+	public fun getNbHits ()I
+	public fun getParams ()Ljava/lang/String;
+	public fun getParsedQuery ()Ljava/lang/String;
+	public fun getParsedQueryOrNull ()Ljava/lang/String;
+	public fun getProcessingTimeMS ()J
+	public fun getQuery ()Ljava/lang/String;
+	public fun getQueryOrNull ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMulti$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchPlacesMulti$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchPlacesMulti;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchPlacesMulti$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchRules {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchRules$Companion;
+	public synthetic fun <init> (ILjava/util/List;IIILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;III)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (Ljava/util/List;III)Lcom/algolia/search/model/response/ResponseSearchRules;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchRules;Ljava/util/List;IIIILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchRules;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHits ()Ljava/util/List;
+	public final fun getNbHits ()I
+	public final fun getNbPages ()I
+	public final fun getPage ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchRules;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchRules$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchRules$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchRules;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchRules;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchRules$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchRules$Hit {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchRules$Hit$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/rule/Rule;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/rule/Rule;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/rule/Rule;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/rule/Rule;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/response/ResponseSearchRules$Hit;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchRules$Hit;Lcom/algolia/search/model/rule/Rule;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchRules$Hit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getRule ()Lcom/algolia/search/model/rule/Rule;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchRules$Hit$Companion : kotlinx/serialization/DeserializationStrategy, kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchRules$Hit;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchRules$Hit;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchSynonyms {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchSynonyms$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/List;I)Lcom/algolia/search/model/response/ResponseSearchSynonyms;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchSynonyms;Ljava/util/List;IILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchSynonyms;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHits ()Ljava/util/List;
+	public final fun getNbHits ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchSynonyms;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchSynonyms$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchSynonyms$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchSynonyms;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchSynonyms;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchSynonyms$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchSynonyms$Hit {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/synonym/Synonym;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/synonym/Synonym;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/synonym/Synonym;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/synonym/Synonym;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit;Lcom/algolia/search/model/synonym/Synonym;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHighlightResult ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHighlightResultOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSynonym ()Lcom/algolia/search/model/synonym/Synonym;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchSynonyms$Hit$Companion : kotlinx/serialization/DeserializationStrategy, kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchSynonyms$Hit;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchUserID {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearchUserID$Companion;
+	public synthetic fun <init> (ILjava/util/List;IIILcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;IIILcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Ljava/util/List;IIILcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/ResponseSearchUserID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearchUserID;Ljava/util/List;IIILcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearchUserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHits ()Ljava/util/List;
+	public final fun getHitsPerPage ()I
+	public final fun getNbHits ()I
+	public final fun getPage ()I
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearchUserID;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearchUserID$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearchUserID$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearchUserID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearchUserID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearchUserID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearches {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseSearches$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/response/ResponseSearches;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseSearches;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseSearches;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseSearches;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseSearches$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseSearches$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseSearches;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseSearches;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseSearches$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseTopUserID {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseTopUserID$Companion;
+	public synthetic fun <init> (ILjava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/algolia/search/model/response/ResponseTopUserID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseTopUserID;Ljava/util/Map;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseTopUserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTopUsers ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseTopUserID;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseTopUserID$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseTopUserID$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseTopUserID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseTopUserID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseTopUserID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseUserID {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseUserID$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/multicluster/UserID;JJLcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/multicluster/UserID;JJLcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/multicluster/UserID;JJLcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/multicluster/UserID;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun component5 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/multicluster/UserID;JJLcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/response/ResponseUserID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseUserID;Lcom/algolia/search/model/multicluster/UserID;JJLcom/algolia/search/model/multicluster/ClusterName;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseUserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClusterName ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun getClusterNameOrNull ()Lcom/algolia/search/model/multicluster/ClusterName;
+	public final fun getDataSize ()J
+	public final fun getHighlightResults ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHighlightResultsOrNull ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getNbRecords ()J
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getObjectIDOrNull ()Lcom/algolia/search/model/ObjectID;
+	public final fun getUserID ()Lcom/algolia/search/model/multicluster/UserID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseUserID;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseUserID$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseUserID$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseUserID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseUserID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseUserID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseVariant {
+	public static final field Companion Lcom/algolia/search/model/response/ResponseVariant$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Float;Lcom/algolia/search/model/search/Query;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Float;Lcom/algolia/search/model/search/Query;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/IndexName;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Float;Lcom/algolia/search/model/search/Query;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/Float;
+	public final fun component13 ()Lcom/algolia/search/model/search/Query;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Float;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Float;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Lcom/algolia/search/model/IndexName;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Float;Lcom/algolia/search/model/search/Query;)Lcom/algolia/search/model/response/ResponseVariant;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResponseVariant;Lcom/algolia/search/model/IndexName;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Float;Lcom/algolia/search/model/search/Query;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResponseVariant;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAverageClickPosition ()F
+	public final fun getAverageClickPositionOrNull ()Ljava/lang/Float;
+	public final fun getClickCount ()I
+	public final fun getClickCountOrNull ()Ljava/lang/Integer;
+	public final fun getClickThroughRate ()F
+	public final fun getClickThroughRateOrNull ()Ljava/lang/Float;
+	public final fun getConversionCount ()I
+	public final fun getConversionCountOrNull ()Ljava/lang/Integer;
+	public final fun getConversionRate ()F
+	public final fun getConversionRateOrNull ()Ljava/lang/Float;
+	public final fun getCustomSearchParameters ()Lcom/algolia/search/model/search/Query;
+	public final fun getCustomSearchParametersOrNull ()Lcom/algolia/search/model/search/Query;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDescriptionOrNull ()Ljava/lang/String;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public final fun getNoResultCount ()I
+	public final fun getNoResultCountOrNull ()Ljava/lang/Integer;
+	public final fun getSearchCount ()J
+	public final fun getSearchCountOrNull ()Ljava/lang/Long;
+	public final fun getTrackedSearchCount ()J
+	public final fun getTrackedSearchCountOrNull ()Ljava/lang/Long;
+	public final fun getTrafficPercentage ()I
+	public final fun getUserCount ()J
+	public final fun getUserCountOrNull ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/ResponseVariant;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/ResponseVariant$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/ResponseVariant$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/ResponseVariant;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/ResponseVariant;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/ResponseVariant$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/response/ResultMultiSearch {
+	public abstract fun getResponse ()Lcom/algolia/search/model/response/ResultSearch;
+}
+
+public final class com/algolia/search/model/response/ResultMultiSearch$Facets : com/algolia/search/model/response/ResultMultiSearch {
+	public fun <init> (Lcom/algolia/search/model/response/ResponseSearchForFacets;)V
+	public final fun component1 ()Lcom/algolia/search/model/response/ResponseSearchForFacets;
+	public final fun copy (Lcom/algolia/search/model/response/ResponseSearchForFacets;)Lcom/algolia/search/model/response/ResultMultiSearch$Facets;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResultMultiSearch$Facets;Lcom/algolia/search/model/response/ResponseSearchForFacets;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResultMultiSearch$Facets;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getResponse ()Lcom/algolia/search/model/response/ResponseSearchForFacets;
+	public synthetic fun getResponse ()Lcom/algolia/search/model/response/ResultSearch;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/ResultMultiSearch$Hits : com/algolia/search/model/response/ResultMultiSearch {
+	public fun <init> (Lcom/algolia/search/model/response/ResponseSearch;)V
+	public final fun component1 ()Lcom/algolia/search/model/response/ResponseSearch;
+	public final fun copy (Lcom/algolia/search/model/response/ResponseSearch;)Lcom/algolia/search/model/response/ResultMultiSearch$Hits;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/ResultMultiSearch$Hits;Lcom/algolia/search/model/response/ResponseSearch;ILjava/lang/Object;)Lcom/algolia/search/model/response/ResultMultiSearch$Hits;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getResponse ()Lcom/algolia/search/model/response/ResponseSearch;
+	public synthetic fun getResponse ()Lcom/algolia/search/model/response/ResultSearch;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/algolia/search/model/response/ResultSearch {
+}
+
+public final class com/algolia/search/model/response/creation/Creation {
+	public static final field Companion Lcom/algolia/search/model/response/creation/Creation$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/creation/Creation;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/creation/Creation;Lcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/creation/Creation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/creation/Creation;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/creation/Creation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/creation/Creation$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/creation/Creation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/creation/Creation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/Creation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationABTest : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/creation/CreationABTest$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)V
+	public final fun component1 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/IndexName;
+	public final fun copy (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)Lcom/algolia/search/model/response/creation/CreationABTest;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/creation/CreationABTest;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;ILjava/lang/Object;)Lcom/algolia/search/model/response/creation/CreationABTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestID ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/creation/CreationABTest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/creation/CreationABTest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/creation/CreationABTest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/creation/CreationABTest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/creation/CreationABTest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationABTest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationAPIKey {
+	public static final field Companion Lcom/algolia/search/model/response/creation/CreationAPIKey$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Lcom/algolia/search/model/APIKey;
+	public final fun component2 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/creation/CreationAPIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/creation/CreationAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/creation/CreationAPIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiKey ()Lcom/algolia/search/model/APIKey;
+	public final fun getCreatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/creation/CreationAPIKey;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/creation/CreationAPIKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/creation/CreationAPIKey$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/creation/CreationAPIKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/creation/CreationAPIKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationAPIKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationObject : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/creation/CreationObject$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/ObjectID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)Lcom/algolia/search/model/response/creation/CreationObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/creation/CreationObject;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;ILjava/lang/Object;)Lcom/algolia/search/model/response/creation/CreationObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/creation/CreationObject;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/creation/CreationObject$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/creation/CreationObject$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/creation/CreationObject;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/creation/CreationObject;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/creation/CreationObject$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/Deletion {
+	public static final field Companion Lcom/algolia/search/model/response/deletion/Deletion$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/deletion/Deletion;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/deletion/Deletion;Lcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/deletion/Deletion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeletedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/deletion/Deletion;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/deletion/Deletion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/deletion/Deletion$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/deletion/Deletion;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/deletion/Deletion;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/Deletion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionABTest : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/deletion/DeletionABTest$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)V
+	public final fun component1 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/IndexName;
+	public final fun copy (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)Lcom/algolia/search/model/response/deletion/DeletionABTest;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/deletion/DeletionABTest;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;ILjava/lang/Object;)Lcom/algolia/search/model/response/deletion/DeletionABTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestID ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/deletion/DeletionABTest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionABTest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/deletion/DeletionABTest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/deletion/DeletionABTest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/deletion/DeletionABTest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionABTest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionAPIKey {
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/APIKey;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/APIKey;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/APIKey;)Lcom/algolia/search/model/response/deletion/DeletionAPIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/deletion/DeletionAPIKey;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/APIKey;ILjava/lang/Object;)Lcom/algolia/search/model/response/deletion/DeletionAPIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiKey ()Lcom/algolia/search/model/APIKey;
+	public final fun getDeletedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionIndex : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/deletion/DeletionIndex$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;)Lcom/algolia/search/model/response/deletion/DeletionIndex;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/deletion/DeletionIndex;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;ILjava/lang/Object;)Lcom/algolia/search/model/response/deletion/DeletionIndex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeletedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/deletion/DeletionIndex;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionIndex$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/deletion/DeletionIndex$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/deletion/DeletionIndex;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/deletion/DeletionIndex;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionIndex$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionObject : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/deletion/DeletionObject$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/ObjectID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)Lcom/algolia/search/model/response/deletion/DeletionObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/deletion/DeletionObject;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;ILjava/lang/Object;)Lcom/algolia/search/model/response/deletion/DeletionObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeletedAt ()Lcom/algolia/search/model/ClientDate;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/deletion/DeletionObject;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionObject$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/deletion/DeletionObject$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/deletion/DeletionObject;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/deletion/DeletionObject;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/deletion/DeletionObject$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/Revision {
+	public static final field Companion Lcom/algolia/search/model/response/revision/Revision$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/revision/Revision;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/Revision;Lcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/Revision;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/Revision;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/Revision$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/Revision$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/Revision;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/Revision;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/Revision$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionABTest : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/revision/RevisionABTest$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)V
+	public final fun component1 ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/IndexName;
+	public final fun copy (Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;)Lcom/algolia/search/model/response/revision/RevisionABTest;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/RevisionABTest;Lcom/algolia/search/model/analytics/ABTestID;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/IndexName;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/RevisionABTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbTestID ()Lcom/algolia/search/model/analytics/ABTestID;
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/RevisionABTest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/RevisionABTest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/RevisionABTest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/RevisionABTest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/RevisionABTest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionABTest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionAPIKey {
+	public static final field Companion Lcom/algolia/search/model/response/revision/RevisionAPIKey$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;)V
+	public final fun component1 ()Lcom/algolia/search/model/APIKey;
+	public final fun component2 ()Lcom/algolia/search/model/ClientDate;
+	public final fun copy (Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;)Lcom/algolia/search/model/response/revision/RevisionAPIKey;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/RevisionAPIKey;Lcom/algolia/search/model/APIKey;Lcom/algolia/search/model/ClientDate;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/RevisionAPIKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiKey ()Lcom/algolia/search/model/APIKey;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/RevisionAPIKey;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/RevisionAPIKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/RevisionAPIKey$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/RevisionAPIKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/RevisionAPIKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionAPIKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionIndex : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/revision/RevisionIndex$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;)Lcom/algolia/search/model/response/revision/RevisionIndex;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/RevisionIndex;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/RevisionIndex;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/RevisionIndex;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/RevisionIndex$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/RevisionIndex$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/RevisionIndex;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/RevisionIndex;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionIndex$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionObject : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/revision/RevisionObject$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun component3 ()Lcom/algolia/search/model/ObjectID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;)Lcom/algolia/search/model/response/revision/RevisionObject;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/RevisionObject;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/task/TaskID;Lcom/algolia/search/model/ObjectID;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/RevisionObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/RevisionObject;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/RevisionObject$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/RevisionObject$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/RevisionObject;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/RevisionObject;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionObject$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionSynonym : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/response/revision/RevisionSynonym$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/task/TaskID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/task/TaskID;)V
+	public final fun component1 ()Lcom/algolia/search/model/ClientDate;
+	public final fun component2 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component3 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun copy (Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/task/TaskID;)Lcom/algolia/search/model/response/revision/RevisionSynonym;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/response/revision/RevisionSynonym;Lcom/algolia/search/model/ClientDate;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/task/TaskID;ILjava/lang/Object;)Lcom/algolia/search/model/response/revision/RevisionSynonym;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public final fun getUpdatedAt ()Lcom/algolia/search/model/ClientDate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/response/revision/RevisionSynonym;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/response/revision/RevisionSynonym$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/response/revision/RevisionSynonym$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/response/revision/RevisionSynonym;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/response/revision/RevisionSynonym;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/response/revision/RevisionSynonym$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/rule/Alternatives {
+	public static final field Companion Lcom/algolia/search/model/rule/Alternatives$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class com/algolia/search/model/rule/Alternatives$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Alternatives;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Alternatives;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/model/rule/Alternatives$False : com/algolia/search/model/rule/Alternatives {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Alternatives$False;
+}
+
+public final class com/algolia/search/model/rule/Alternatives$True : com/algolia/search/model/rule/Alternatives {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Alternatives$True;
+}
+
+public abstract class com/algolia/search/model/rule/Anchoring : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/rule/Anchoring$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Anchoring;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Anchoring;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$Contains : com/algolia/search/model/rule/Anchoring {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Anchoring$Contains;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$EndsWith : com/algolia/search/model/rule/Anchoring {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Anchoring$EndsWith;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$Is : com/algolia/search/model/rule/Anchoring {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Anchoring$Is;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$Other : com/algolia/search/model/rule/Anchoring {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/rule/Anchoring$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Anchoring$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Anchoring$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Anchoring$StartsWith : com/algolia/search/model/rule/Anchoring {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Anchoring$StartsWith;
+}
+
+public final class com/algolia/search/model/rule/AutomaticFacetFilters {
+	public static final field Companion Lcom/algolia/search/model/rule/AutomaticFacetFilters$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/AutomaticFacetFilters;Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getDisjunctive ()Ljava/lang/Boolean;
+	public final fun getScore ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/AutomaticFacetFilters;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/AutomaticFacetFilters$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/AutomaticFacetFilters$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/AutomaticFacetFilters;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/AutomaticFacetFilters;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/AutomaticFacetFilters$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Condition {
+	public static final field Companion Lcom/algolia/search/model/rule/Condition$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/rule/Anchoring;
+	public final fun component2 ()Lcom/algolia/search/model/rule/Pattern;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/algolia/search/model/rule/Alternatives;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;)Lcom/algolia/search/model/rule/Condition;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Condition;Lcom/algolia/search/model/rule/Anchoring;Lcom/algolia/search/model/rule/Pattern;Ljava/lang/String;Lcom/algolia/search/model/rule/Alternatives;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Condition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlternative ()Lcom/algolia/search/model/rule/Alternatives;
+	public final fun getAnchoring ()Lcom/algolia/search/model/rule/Anchoring;
+	public final fun getContext ()Ljava/lang/String;
+	public final fun getFilters ()Ljava/lang/String;
+	public final fun getPattern ()Lcom/algolia/search/model/rule/Pattern;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/Condition;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/Condition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Condition$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Condition;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Condition;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Condition$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Consequence {
+	public static final field Companion Lcom/algolia/search/model/rule/Consequence$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/rule/RenderingContent;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/rule/RenderingContent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lcom/algolia/search/model/search/Query;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component9 ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/rule/RenderingContent;)Lcom/algolia/search/model/rule/Consequence;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Consequence;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/Query;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/rule/RenderingContent;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Consequence;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutomaticFacetFilters ()Ljava/util/List;
+	public final fun getAutomaticOptionalFacetFilters ()Ljava/util/List;
+	public final fun getEdits ()Ljava/util/List;
+	public final fun getFilterPromotes ()Ljava/lang/Boolean;
+	public final fun getHide ()Ljava/util/List;
+	public final fun getPromote ()Ljava/util/List;
+	public final fun getQuery ()Lcom/algolia/search/model/search/Query;
+	public final fun getRenderingContent ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun getUserData ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Consequence$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Consequence;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Consequence;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Edit {
+	public static final field Companion Lcom/algolia/search/model/rule/Edit$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/algolia/search/model/rule/Edit;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Edit;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Edit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDelete ()Ljava/lang/String;
+	public final fun getInsert ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Edit$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Edit;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Edit;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetOrdering {
+	public static final field Companion Lcom/algolia/search/model/rule/FacetOrdering$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/rule/FacetsOrder;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/rule/FacetsOrder;Ljava/util/Map;)V
+	public final fun component1 ()Lcom/algolia/search/model/rule/FacetsOrder;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Lcom/algolia/search/model/rule/FacetsOrder;Ljava/util/Map;)Lcom/algolia/search/model/rule/FacetOrdering;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/FacetOrdering;Lcom/algolia/search/model/rule/FacetsOrder;Ljava/util/Map;ILjava/lang/Object;)Lcom/algolia/search/model/rule/FacetOrdering;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFacets ()Lcom/algolia/search/model/rule/FacetsOrder;
+	public final fun getValues ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/FacetOrdering;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/FacetOrdering$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/FacetOrdering$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/FacetOrdering;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/FacetOrdering;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetOrdering$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetValuesOrder {
+	public static final field Companion Lcom/algolia/search/model/rule/FacetValuesOrder$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Lcom/algolia/search/model/rule/SortRule;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lcom/algolia/search/model/rule/SortRule;)V
+	public synthetic fun <init> (Ljava/util/List;Lcom/algolia/search/model/rule/SortRule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lcom/algolia/search/model/rule/SortRule;
+	public final fun copy (Ljava/util/List;Lcom/algolia/search/model/rule/SortRule;)Lcom/algolia/search/model/rule/FacetValuesOrder;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/FacetValuesOrder;Ljava/util/List;Lcom/algolia/search/model/rule/SortRule;ILjava/lang/Object;)Lcom/algolia/search/model/rule/FacetValuesOrder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOrder ()Ljava/util/List;
+	public final fun getSortRemainingBy ()Lcom/algolia/search/model/rule/SortRule;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/FacetValuesOrder;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/FacetValuesOrder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/FacetValuesOrder$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/FacetValuesOrder;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/FacetValuesOrder;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetValuesOrder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetsOrder {
+	public static final field Companion Lcom/algolia/search/model/rule/FacetsOrder$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/rule/FacetsOrder;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/FacetsOrder;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/rule/FacetsOrder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOrder ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/FacetsOrder;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/FacetsOrder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/FacetsOrder$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/FacetsOrder;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/FacetsOrder;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/FacetsOrder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/rule/Pattern : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/rule/Pattern$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Pattern$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Pattern;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Pattern;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Pattern$Facet : com/algolia/search/model/rule/Pattern {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Pattern$Facet;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Pattern$Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/rule/Pattern$Literal : com/algolia/search/model/rule/Pattern {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/rule/Pattern$Literal;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Pattern$Literal;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Pattern$Literal;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/rule/Promotion {
+	public static final field Companion Lcom/algolia/search/model/rule/Promotion$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getPosition ()I
+	public static final fun write$Self (Lcom/algolia/search/model/rule/Promotion;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/Promotion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Promotion$Multiple : com/algolia/search/model/rule/Promotion {
+	public static final field Companion Lcom/algolia/search/model/rule/Promotion$Multiple$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/List;I)Lcom/algolia/search/model/rule/Promotion$Multiple;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Promotion$Multiple;Ljava/util/List;IILjava/lang/Object;)Lcom/algolia/search/model/rule/Promotion$Multiple;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectIDs ()Ljava/util/List;
+	public fun getPosition ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/Promotion$Multiple;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/Promotion$Multiple$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Promotion$Multiple$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Promotion$Multiple;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Promotion$Multiple;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Promotion$Multiple$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Promotion$Single : com/algolia/search/model/rule/Promotion {
+	public static final field Companion Lcom/algolia/search/model/rule/Promotion$Single$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ObjectID;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ObjectID;I)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()I
+	public final fun copy (Lcom/algolia/search/model/ObjectID;I)Lcom/algolia/search/model/rule/Promotion$Single;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Promotion$Single;Lcom/algolia/search/model/ObjectID;IILjava/lang/Object;)Lcom/algolia/search/model/rule/Promotion$Single;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun getPosition ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/Promotion$Single;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/Promotion$Single$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Promotion$Single$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Promotion$Single;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Promotion$Single;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Promotion$Single$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/PromotionKt {
+	public static final fun Promotion (Lcom/algolia/search/model/ObjectID;I)Lcom/algolia/search/model/rule/Promotion$Single;
+	public static final fun Promotion (Ljava/util/List;I)Lcom/algolia/search/model/rule/Promotion$Multiple;
+}
+
+public final class com/algolia/search/model/rule/RenderingContent {
+	public static final field Companion Lcom/algolia/search/model/rule/RenderingContent$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILcom/algolia/search/model/rule/FacetOrdering;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/rule/FacetOrdering;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/rule/FacetOrdering;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/rule/FacetOrdering;
+	public final fun copy (Lcom/algolia/search/model/rule/FacetOrdering;)Lcom/algolia/search/model/rule/RenderingContent;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/rule/FacetOrdering;ILjava/lang/Object;)Lcom/algolia/search/model/rule/RenderingContent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFacetOrdering ()Lcom/algolia/search/model/rule/FacetOrdering;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/RenderingContent;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/RenderingContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/RenderingContent$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/RenderingContent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/RenderingContent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/RenderingContent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Rule {
+	public static final field Companion Lcom/algolia/search/model/rule/Rule$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lcom/algolia/search/model/rule/Consequence;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;)Lcom/algolia/search/model/rule/Rule;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/Rule;Lcom/algolia/search/model/ObjectID;Ljava/util/List;Lcom/algolia/search/model/rule/Consequence;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/rule/Rule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getConsequence ()Lcom/algolia/search/model/rule/Consequence;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getValidity ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/Rule;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/Rule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/Rule$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/Rule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/Rule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/Rule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/RuleQuery {
+	public static final field Companion Lcom/algolia/search/model/rule/RuleQuery$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lcom/algolia/search/model/rule/Anchoring;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/rule/Anchoring;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/algolia/search/model/rule/Anchoring;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/rule/Anchoring;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/rule/Anchoring;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;)Lcom/algolia/search/model/rule/RuleQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/RuleQuery;Ljava/lang/String;Lcom/algolia/search/model/rule/Anchoring;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/algolia/search/model/rule/RuleQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnchoring ()Lcom/algolia/search/model/rule/Anchoring;
+	public final fun getContains ()Lcom/algolia/search/model/rule/Anchoring$Contains;
+	public final fun getContext ()Ljava/lang/String;
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getEndsWith ()Lcom/algolia/search/model/rule/Anchoring$EndsWith;
+	public final fun getHitsPerPage ()Ljava/lang/Integer;
+	public final fun getIs ()Lcom/algolia/search/model/rule/Anchoring$Is;
+	public final fun getPage ()Ljava/lang/Integer;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getStartsWith ()Lcom/algolia/search/model/rule/Anchoring$StartsWith;
+	public fun hashCode ()I
+	public final fun setAnchoring (Lcom/algolia/search/model/rule/Anchoring;)V
+	public final fun setContext (Ljava/lang/String;)V
+	public final fun setEnabled (Ljava/lang/Boolean;)V
+	public final fun setHitsPerPage (Ljava/lang/Integer;)V
+	public final fun setPage (Ljava/lang/Integer;)V
+	public final fun setQuery (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/RuleQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/RuleQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/RuleQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/RuleQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/RuleQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/RuleQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/SortRule : java/lang/Enum {
+	public static final field Alpha Lcom/algolia/search/model/rule/SortRule;
+	public static final field Companion Lcom/algolia/search/model/rule/SortRule$Companion;
+	public static final field Count Lcom/algolia/search/model/rule/SortRule;
+	public static final field Hidden Lcom/algolia/search/model/rule/SortRule;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/model/rule/SortRule;
+	public static fun values ()[Lcom/algolia/search/model/rule/SortRule;
+}
+
+public final class com/algolia/search/model/rule/SortRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/SortRule$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/SortRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/SortRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/SortRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/TimeRange {
+	public static final field Companion Lcom/algolia/search/model/rule/TimeRange$Companion;
+	public synthetic fun <init> (IJJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lcom/algolia/search/model/rule/TimeRange;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/rule/TimeRange;JJILjava/lang/Object;)Lcom/algolia/search/model/rule/TimeRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()J
+	public final fun getUntil ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/rule/TimeRange;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/rule/TimeRange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/rule/TimeRange$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/rule/TimeRange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/rule/TimeRange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/rule/TimeRange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Alternative {
+	public static final field Companion Lcom/algolia/search/model/search/Alternative$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;IIILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;III)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun copy (Ljava/util/List;Ljava/util/List;III)Lcom/algolia/search/model/search/Alternative;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Alternative;Ljava/util/List;Ljava/util/List;IIIILjava/lang/Object;)Lcom/algolia/search/model/search/Alternative;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLength ()I
+	public final fun getOffset ()I
+	public final fun getTypes ()Ljava/util/List;
+	public final fun getTypos ()I
+	public final fun getWords ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Alternative;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Alternative$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Alternative$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Alternative;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Alternative;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Alternative$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/AlternativeType : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/AlternativeType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$AlternativeCorrection : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$AlternativeCorrection;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/AlternativeType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/AlternativeType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Compound : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Compound;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Concat : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Concat;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Excluded : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Excluded;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Optional : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Optional;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Original : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Original;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Other : com/algolia/search/model/search/AlternativeType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/AlternativeType$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AlternativeType$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/AlternativeType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Plural : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Plural;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Split : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Split;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$StopWord : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$StopWord;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Synonym : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Synonym;
+}
+
+public final class com/algolia/search/model/search/AlternativeType$Typo : com/algolia/search/model/search/AlternativeType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativeType$Typo;
+}
+
+public abstract class com/algolia/search/model/search/AlternativesAsExact : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/AlternativesAsExact$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AlternativesAsExact$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/AlternativesAsExact;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/AlternativesAsExact;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/AlternativesAsExact$IgnorePlurals : com/algolia/search/model/search/AlternativesAsExact {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativesAsExact$IgnorePlurals;
+}
+
+public final class com/algolia/search/model/search/AlternativesAsExact$MultiWordsSynonym : com/algolia/search/model/search/AlternativesAsExact {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativesAsExact$MultiWordsSynonym;
+}
+
+public final class com/algolia/search/model/search/AlternativesAsExact$Other : com/algolia/search/model/search/AlternativesAsExact {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/AlternativesAsExact$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AlternativesAsExact$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/AlternativesAsExact$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AlternativesAsExact$SingleWordSynonym : com/algolia/search/model/search/AlternativesAsExact {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AlternativesAsExact$SingleWordSynonym;
+}
+
+public final class com/algolia/search/model/search/AnswersQuery : com/algolia/search/model/params/AnswersParameters, com/algolia/search/model/params/CommonSearchParameters {
+	public static final field Companion Lcom/algolia/search/model/search/AnswersQuery$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Float;Lcom/algolia/search/model/search/SearchParameters;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Float;Lcom/algolia/search/model/search/SearchParameters;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Float;Lcom/algolia/search/model/search/SearchParameters;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Float;
+	public final fun component6 ()Lcom/algolia/search/model/search/SearchParameters;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Float;Lcom/algolia/search/model/search/SearchParameters;)Lcom/algolia/search/model/search/AnswersQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AnswersQuery;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Float;Lcom/algolia/search/model/search/SearchParameters;ILjava/lang/Object;)Lcom/algolia/search/model/search/AnswersQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public fun getAlternativesAsExact ()Ljava/util/List;
+	public fun getAnalytics ()Ljava/lang/Boolean;
+	public fun getAnalyticsTags ()Ljava/util/List;
+	public fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun getAttributesForPrediction ()Ljava/util/List;
+	public fun getAttributesToHighlight ()Ljava/util/List;
+	public fun getAttributesToRetrieve ()Ljava/util/List;
+	public fun getClickAnalytics ()Ljava/lang/Boolean;
+	public fun getDisableExactOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public fun getEnableABTest ()Ljava/lang/Boolean;
+	public fun getEnablePersonalization ()Ljava/lang/Boolean;
+	public fun getEnableRules ()Ljava/lang/Boolean;
+	public fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public fun getExplainModules ()Ljava/util/List;
+	public fun getFacetFilters ()Ljava/util/List;
+	public fun getFacetingAfterDistinct ()Ljava/lang/Boolean;
+	public fun getFacets ()Ljava/util/Set;
+	public fun getFilters ()Ljava/lang/String;
+	public fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public fun getHighlightPostTag ()Ljava/lang/String;
+	public fun getHighlightPreTag ()Ljava/lang/String;
+	public fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public fun getInsideBoundingBox ()Ljava/util/List;
+	public fun getInsidePolygon ()Ljava/util/List;
+	public fun getLength ()Ljava/lang/Integer;
+	public fun getMaxFacetHits ()Ljava/lang/Integer;
+	public fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public fun getMinProximity ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public fun getMinimumAroundRadius ()Ljava/lang/Integer;
+	public fun getNaturalLanguages ()Ljava/util/List;
+	public final fun getNbHits ()Ljava/lang/Integer;
+	public fun getNumericFilters ()Ljava/util/List;
+	public fun getOffset ()Ljava/lang/Integer;
+	public fun getOptionalFilters ()Ljava/util/List;
+	public fun getOptionalWords ()Ljava/util/List;
+	public fun getPage ()Ljava/lang/Integer;
+	public final fun getParams ()Lcom/algolia/search/model/search/SearchParameters;
+	public fun getPercentileComputation ()Ljava/lang/Boolean;
+	public fun getPersonalizationImpact ()Ljava/lang/Integer;
+	public fun getQuery ()Ljava/lang/String;
+	public final fun getQueryLanguages ()Ljava/util/List;
+	public fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public fun getResponseFields ()Ljava/util/List;
+	public fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public fun getRuleContexts ()Ljava/util/List;
+	public fun getSimilarQuery ()Ljava/lang/String;
+	public fun getSnippetEllipsisText ()Ljava/lang/String;
+	public fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public fun getSumOrFiltersScores ()Ljava/lang/Boolean;
+	public fun getSynonyms ()Ljava/lang/Boolean;
+	public fun getTagFilters ()Ljava/util/List;
+	public final fun getThreshold ()Ljava/lang/Float;
+	public fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public fun setAlternativesAsExact (Ljava/util/List;)V
+	public fun setAnalytics (Ljava/lang/Boolean;)V
+	public fun setAnalyticsTags (Ljava/util/List;)V
+	public fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public final fun setAttributesForPrediction (Ljava/util/List;)V
+	public fun setAttributesToHighlight (Ljava/util/List;)V
+	public fun setAttributesToRetrieve (Ljava/util/List;)V
+	public fun setClickAnalytics (Ljava/lang/Boolean;)V
+	public fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public fun setEnableABTest (Ljava/lang/Boolean;)V
+	public fun setEnablePersonalization (Ljava/lang/Boolean;)V
+	public fun setEnableRules (Ljava/lang/Boolean;)V
+	public fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public fun setExplainModules (Ljava/util/List;)V
+	public fun setFacetFilters (Ljava/util/List;)V
+	public fun setFacetingAfterDistinct (Ljava/lang/Boolean;)V
+	public fun setFacets (Ljava/util/Set;)V
+	public fun setFilters (Ljava/lang/String;)V
+	public fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public fun setHighlightPostTag (Ljava/lang/String;)V
+	public fun setHighlightPreTag (Ljava/lang/String;)V
+	public fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public fun setInsideBoundingBox (Ljava/util/List;)V
+	public fun setInsidePolygon (Ljava/util/List;)V
+	public fun setLength (Ljava/lang/Integer;)V
+	public fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public fun setMinProximity (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public fun setMinimumAroundRadius (Ljava/lang/Integer;)V
+	public fun setNaturalLanguages (Ljava/util/List;)V
+	public fun setNumericFilters (Ljava/util/List;)V
+	public fun setOffset (Ljava/lang/Integer;)V
+	public fun setOptionalFilters (Ljava/util/List;)V
+	public fun setOptionalWords (Ljava/util/List;)V
+	public fun setPage (Ljava/lang/Integer;)V
+	public fun setPercentileComputation (Ljava/lang/Boolean;)V
+	public fun setPersonalizationImpact (Ljava/lang/Integer;)V
+	public fun setQuery (Ljava/lang/String;)V
+	public final fun setQueryLanguages (Ljava/util/List;)V
+	public fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public fun setResponseFields (Ljava/util/List;)V
+	public fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public fun setRuleContexts (Ljava/util/List;)V
+	public fun setSimilarQuery (Ljava/lang/String;)V
+	public fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public fun setSumOrFiltersScores (Ljava/lang/Boolean;)V
+	public fun setSynonyms (Ljava/lang/Boolean;)V
+	public fun setTagFilters (Ljava/util/List;)V
+	public fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+	public fun setUserToken (Lcom/algolia/search/model/insights/UserToken;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/AnswersQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/AnswersQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AnswersQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/AnswersQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/AnswersQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/AnswersQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/AroundPrecision {
+	public static final field Companion Lcom/algolia/search/model/search/AroundPrecision$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class com/algolia/search/model/search/AroundPrecision$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/AroundPrecision;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/AroundPrecision;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/AroundPrecision$Int : com/algolia/search/model/search/AroundPrecision {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/algolia/search/model/search/AroundPrecision$Int;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AroundPrecision$Int;IILjava/lang/Object;)Lcom/algolia/search/model/search/AroundPrecision$Int;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AroundPrecision$Other : com/algolia/search/model/search/AroundPrecision {
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lcom/algolia/search/model/search/AroundPrecision$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AroundPrecision$Other;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/algolia/search/model/search/AroundPrecision$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRaw ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AroundPrecision$Ranges : com/algolia/search/model/search/AroundPrecision {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lkotlin/ranges/IntRange;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/search/AroundPrecision$Ranges;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AroundPrecision$Ranges;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/search/AroundPrecision$Ranges;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/search/AroundRadius : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/AroundRadius$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AroundRadius$All : com/algolia/search/model/search/AroundRadius {
+	public static final field INSTANCE Lcom/algolia/search/model/search/AroundRadius$All;
+}
+
+public final class com/algolia/search/model/search/AroundRadius$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/AroundRadius;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/AroundRadius;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/AroundRadius$InMeters : com/algolia/search/model/search/AroundRadius {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/algolia/search/model/search/AroundRadius$InMeters;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AroundRadius$InMeters;IILjava/lang/Object;)Lcom/algolia/search/model/search/AroundRadius$InMeters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRadius ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/AroundRadius$Other : com/algolia/search/model/search/AroundRadius {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/AroundRadius$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/AroundRadius$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/AroundRadius$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/BoundingBox : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/BoundingBox$Companion;
+	public fun <init> (Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Point;
+	public final fun component2 ()Lcom/algolia/search/model/search/Point;
+	public final fun copy (Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;)Lcom/algolia/search/model/search/BoundingBox;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/BoundingBox;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;ILjava/lang/Object;)Lcom/algolia/search/model/search/BoundingBox;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPoint1 ()Lcom/algolia/search/model/search/Point;
+	public final fun getPoint2 ()Lcom/algolia/search/model/search/Point;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/BoundingBox$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/BoundingBox;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/BoundingBox;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Cursor : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/Cursor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/Cursor;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Cursor;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/Cursor;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Cursor$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Cursor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Cursor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/ExactOnSingleWordQuery : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/ExactOnSingleWordQuery$Attribute : com/algolia/search/model/search/ExactOnSingleWordQuery {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Attribute;
+}
+
+public final class com/algolia/search/model/search/ExactOnSingleWordQuery$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/ExactOnSingleWordQuery$None : com/algolia/search/model/search/ExactOnSingleWordQuery {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ExactOnSingleWordQuery$None;
+}
+
+public final class com/algolia/search/model/search/ExactOnSingleWordQuery$Other : com/algolia/search/model/search/ExactOnSingleWordQuery {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/ExactOnSingleWordQuery$Word : com/algolia/search/model/search/ExactOnSingleWordQuery {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ExactOnSingleWordQuery$Word;
+}
+
+public final class com/algolia/search/model/search/Explain {
+	public static final field Companion Lcom/algolia/search/model/search/Explain$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/search/Match;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/search/Match;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Match;
+	public final fun copy (Lcom/algolia/search/model/search/Match;)Lcom/algolia/search/model/search/Explain;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Explain;Lcom/algolia/search/model/search/Match;ILjava/lang/Object;)Lcom/algolia/search/model/search/Explain;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMatch ()Lcom/algolia/search/model/search/Match;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Explain;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Explain$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Explain$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Explain;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Explain;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Explain$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/ExplainModule : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/ExplainModule$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/ExplainModule$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/ExplainModule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/ExplainModule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/ExplainModule$MatchAlternatives : com/algolia/search/model/search/ExplainModule {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ExplainModule$MatchAlternatives;
+}
+
+public final class com/algolia/search/model/search/ExplainModule$Other : com/algolia/search/model/search/ExplainModule {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/ExplainModule$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/ExplainModule$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/ExplainModule$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Facet {
+	public static final field Companion Lcom/algolia/search/model/search/Facet$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lcom/algolia/search/model/search/Facet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Facet;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getHighlighted ()Ljava/lang/String;
+	public final fun getHighlightedOrNull ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Facet;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Facet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Facet$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Facet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Facet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Facet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/FacetKt {
+	public static final fun get (Ljava/util/List;Ljava/lang/String;)I
+	public static final fun get (Ljava/util/Map;Lcom/algolia/search/model/Attribute;Ljava/lang/String;)I
+}
+
+public final class com/algolia/search/model/search/FacetStats {
+	public static final field Companion Lcom/algolia/search/model/search/FacetStats$Companion;
+	public fun <init> (FFFF)V
+	public synthetic fun <init> (IFFFFLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun component4 ()F
+	public final fun copy (FFFF)Lcom/algolia/search/model/search/FacetStats;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/FacetStats;FFFFILjava/lang/Object;)Lcom/algolia/search/model/search/FacetStats;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAverage ()F
+	public final fun getMax ()F
+	public final fun getMin ()F
+	public final fun getSum ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/FacetStats;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/FacetStats$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/FacetStats$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/FacetStats;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/FacetStats;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/FacetStats$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/HighlightResult {
+	public static final field Companion Lcom/algolia/search/model/search/HighlightResult$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/search/MatchLevel;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Ljava/util/List;Ljava/lang/Boolean;)Lcom/algolia/search/model/search/HighlightResult;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/HighlightResult;Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/algolia/search/model/search/HighlightResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFullyHighlighted ()Ljava/lang/Boolean;
+	public final fun getMatchLevel ()Lcom/algolia/search/model/search/MatchLevel;
+	public final fun getMatchedWords ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/HighlightResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/HighlightResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/HighlightResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/HighlightResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/HighlightResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/HighlightResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/IgnorePlurals {
+	public static final field Companion Lcom/algolia/search/model/search/IgnorePlurals$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class com/algolia/search/model/search/IgnorePlurals$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/IgnorePlurals;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/IgnorePlurals$False : com/algolia/search/model/search/IgnorePlurals {
+	public static final field INSTANCE Lcom/algolia/search/model/search/IgnorePlurals$False;
+}
+
+public final class com/algolia/search/model/search/IgnorePlurals$QueryLanguages : com/algolia/search/model/search/IgnorePlurals {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lcom/algolia/search/model/search/Language;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/search/IgnorePlurals$QueryLanguages;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/IgnorePlurals$QueryLanguages;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/search/IgnorePlurals$QueryLanguages;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQueryLanguages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/IgnorePlurals$True : com/algolia/search/model/search/IgnorePlurals {
+	public static final field INSTANCE Lcom/algolia/search/model/search/IgnorePlurals$True;
+}
+
+public abstract class com/algolia/search/model/search/Language : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/Language$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Language$Afrikaans : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Afrikaans;
+}
+
+public final class com/algolia/search/model/search/Language$Albanian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Albanian;
+}
+
+public final class com/algolia/search/model/search/Language$Arabic : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Arabic;
+}
+
+public final class com/algolia/search/model/search/Language$Armenian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Armenian;
+}
+
+public final class com/algolia/search/model/search/Language$Azeri : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Azeri;
+}
+
+public final class com/algolia/search/model/search/Language$Basque : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Basque;
+}
+
+public final class com/algolia/search/model/search/Language$Brunei : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Brunei;
+}
+
+public final class com/algolia/search/model/search/Language$Bulgarian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Bulgarian;
+}
+
+public final class com/algolia/search/model/search/Language$Catalan : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Catalan;
+}
+
+public final class com/algolia/search/model/search/Language$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Language;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Language;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Language$Czech : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Czech;
+}
+
+public final class com/algolia/search/model/search/Language$Danish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Danish;
+}
+
+public final class com/algolia/search/model/search/Language$Dutch : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Dutch;
+}
+
+public final class com/algolia/search/model/search/Language$English : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$English;
+}
+
+public final class com/algolia/search/model/search/Language$Esperanto : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Esperanto;
+}
+
+public final class com/algolia/search/model/search/Language$Estonian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Estonian;
+}
+
+public final class com/algolia/search/model/search/Language$Faroese : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Faroese;
+}
+
+public final class com/algolia/search/model/search/Language$Finnish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Finnish;
+}
+
+public final class com/algolia/search/model/search/Language$French : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$French;
+}
+
+public final class com/algolia/search/model/search/Language$Galician : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Galician;
+}
+
+public final class com/algolia/search/model/search/Language$Georgian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Georgian;
+}
+
+public final class com/algolia/search/model/search/Language$German : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$German;
+}
+
+public final class com/algolia/search/model/search/Language$Hebrew : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Hebrew;
+}
+
+public final class com/algolia/search/model/search/Language$Hindi : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Hindi;
+}
+
+public final class com/algolia/search/model/search/Language$Hungarian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Hungarian;
+}
+
+public final class com/algolia/search/model/search/Language$Icelandic : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Icelandic;
+}
+
+public final class com/algolia/search/model/search/Language$Indonesian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Indonesian;
+}
+
+public final class com/algolia/search/model/search/Language$Italian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Italian;
+}
+
+public final class com/algolia/search/model/search/Language$Japanese : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Japanese;
+}
+
+public final class com/algolia/search/model/search/Language$Kazakh : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Kazakh;
+}
+
+public final class com/algolia/search/model/search/Language$Korean : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Korean;
+}
+
+public final class com/algolia/search/model/search/Language$Kyrgyz : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Kyrgyz;
+}
+
+public final class com/algolia/search/model/search/Language$Lithuanian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Lithuanian;
+}
+
+public final class com/algolia/search/model/search/Language$Malay : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Malay;
+}
+
+public final class com/algolia/search/model/search/Language$Maltese : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Maltese;
+}
+
+public final class com/algolia/search/model/search/Language$Maori : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Maori;
+}
+
+public final class com/algolia/search/model/search/Language$Marathi : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Marathi;
+}
+
+public final class com/algolia/search/model/search/Language$Mongolian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Mongolian;
+}
+
+public final class com/algolia/search/model/search/Language$NorthernSotho : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$NorthernSotho;
+}
+
+public final class com/algolia/search/model/search/Language$Norwegian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Norwegian;
+}
+
+public final class com/algolia/search/model/search/Language$Other : com/algolia/search/model/search/Language {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/Language$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Language$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/Language$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Language$Pashto : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Pashto;
+}
+
+public final class com/algolia/search/model/search/Language$Polish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Polish;
+}
+
+public final class com/algolia/search/model/search/Language$Portuguese : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Portuguese;
+}
+
+public final class com/algolia/search/model/search/Language$Quechua : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Quechua;
+}
+
+public final class com/algolia/search/model/search/Language$Romanian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Romanian;
+}
+
+public final class com/algolia/search/model/search/Language$Russian : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Russian;
+}
+
+public final class com/algolia/search/model/search/Language$Slovak : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Slovak;
+}
+
+public final class com/algolia/search/model/search/Language$Spanish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Spanish;
+}
+
+public final class com/algolia/search/model/search/Language$Swahili : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Swahili;
+}
+
+public final class com/algolia/search/model/search/Language$Swedish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Swedish;
+}
+
+public final class com/algolia/search/model/search/Language$Tagalog : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Tagalog;
+}
+
+public final class com/algolia/search/model/search/Language$Tamil : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Tamil;
+}
+
+public final class com/algolia/search/model/search/Language$Tatar : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Tatar;
+}
+
+public final class com/algolia/search/model/search/Language$Telugu : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Telugu;
+}
+
+public final class com/algolia/search/model/search/Language$Tswana : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Tswana;
+}
+
+public final class com/algolia/search/model/search/Language$Turkish : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Turkish;
+}
+
+public final class com/algolia/search/model/search/Language$Welsh : com/algolia/search/model/search/Language {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Language$Welsh;
+}
+
+public final class com/algolia/search/model/search/Match {
+	public static final field Companion Lcom/algolia/search/model/search/Match$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/search/Match;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Match;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/search/Match;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlternatives ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Match;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Match$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Match$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Match;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Match;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Match$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/MatchLevel : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/MatchLevel$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/MatchLevel$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/MatchLevel;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/MatchLevel;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/MatchLevel$Full : com/algolia/search/model/search/MatchLevel {
+	public static final field INSTANCE Lcom/algolia/search/model/search/MatchLevel$Full;
+}
+
+public final class com/algolia/search/model/search/MatchLevel$None : com/algolia/search/model/search/MatchLevel {
+	public static final field INSTANCE Lcom/algolia/search/model/search/MatchLevel$None;
+}
+
+public final class com/algolia/search/model/search/MatchLevel$Other : com/algolia/search/model/search/MatchLevel {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/MatchLevel$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/MatchLevel$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/MatchLevel$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/MatchLevel$Partial : com/algolia/search/model/search/MatchLevel {
+	public static final field INSTANCE Lcom/algolia/search/model/search/MatchLevel$Partial;
+}
+
+public final class com/algolia/search/model/search/MatchedGeoLocation {
+	public static final field Companion Lcom/algolia/search/model/search/MatchedGeoLocation$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> (Lcom/algolia/search/model/search/Point;Ljava/lang/Long;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/search/Point;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Point;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Lcom/algolia/search/model/search/Point;Ljava/lang/Long;)Lcom/algolia/search/model/search/MatchedGeoLocation;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/Long;ILjava/lang/Object;)Lcom/algolia/search/model/search/MatchedGeoLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDistance ()Ljava/lang/Long;
+	public final fun getPoint ()Lcom/algolia/search/model/search/Point;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/MatchedGeoLocation$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/MatchedGeoLocation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/MatchedGeoLocation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Personalization {
+	public static final field Companion Lcom/algolia/search/model/search/Personalization$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/algolia/search/model/search/Personalization;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Personalization;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/algolia/search/model/search/Personalization;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFiltersScore ()I
+	public final fun getFiltersScoreOrNull ()Ljava/lang/Integer;
+	public final fun getRankingScore ()I
+	public final fun getRankingScoreOrNull ()Ljava/lang/Integer;
+	public final fun getScore ()I
+	public final fun getScoreOrNull ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Personalization;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Personalization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Personalization$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Personalization;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Personalization;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Personalization$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Point : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/Point$Companion;
+	public fun <init> (FF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun copy (FF)Lcom/algolia/search/model/search/Point;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Point;FFILjava/lang/Object;)Lcom/algolia/search/model/search/Point;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLatitude ()F
+	public final fun getLongitude ()F
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Point$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Point;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Point;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Polygon : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/Polygon$Companion;
+	public fun <init> (Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Ljava/util/List;)V
+	public fun <init> (Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;[Lcom/algolia/search/model/search/Point;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Point;
+	public final fun component2 ()Lcom/algolia/search/model/search/Point;
+	public final fun component3 ()Lcom/algolia/search/model/search/Point;
+	public final fun copy (Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Ljava/util/List;)Lcom/algolia/search/model/search/Polygon;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Polygon;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Lcom/algolia/search/model/search/Point;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/search/Polygon;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (I)Lcom/algolia/search/model/search/Point;
+	public final fun getPoint1 ()Lcom/algolia/search/model/search/Point;
+	public final fun getPoint2 ()Lcom/algolia/search/model/search/Point;
+	public final fun getPoint3 ()Lcom/algolia/search/model/search/Point;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Polygon$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Polygon;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Polygon;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Query : com/algolia/search/model/params/SearchParameters {
+	public static final field Companion Lcom/algolia/search/model/search/Query$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (IIILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Set;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Ljava/lang/Integer;
+	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component24 ()Ljava/lang/Integer;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Lcom/algolia/search/model/search/TypoTolerance;
+	public final fun component27 ()Ljava/lang/Boolean;
+	public final fun component28 ()Ljava/util/List;
+	public final fun component29 ()Lcom/algolia/search/model/search/Point;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component30 ()Ljava/lang/Boolean;
+	public final fun component31 ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun component32 ()Lcom/algolia/search/model/search/AroundPrecision;
+	public final fun component33 ()Ljava/lang/Integer;
+	public final fun component34 ()Ljava/util/List;
+	public final fun component35 ()Ljava/util/List;
+	public final fun component36 ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public final fun component37 ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public final fun component38 ()Ljava/util/List;
+	public final fun component39 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component40 ()Ljava/util/List;
+	public final fun component41 ()Ljava/lang/Boolean;
+	public final fun component42 ()Ljava/lang/Integer;
+	public final fun component43 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component44 ()Lcom/algolia/search/model/search/QueryType;
+	public final fun component45 ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public final fun component46 ()Ljava/lang/Boolean;
+	public final fun component47 ()Ljava/util/List;
+	public final fun component48 ()Ljava/util/List;
+	public final fun component49 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component50 ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public final fun component51 ()Ljava/util/List;
+	public final fun component52 ()Lcom/algolia/search/model/settings/Distinct;
+	public final fun component53 ()Ljava/lang/Boolean;
+	public final fun component54 ()Ljava/lang/Boolean;
+	public final fun component55 ()Ljava/lang/Boolean;
+	public final fun component56 ()Ljava/util/List;
+	public final fun component57 ()Ljava/lang/Boolean;
+	public final fun component58 ()Ljava/lang/Boolean;
+	public final fun component59 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component60 ()Ljava/util/List;
+	public final fun component61 ()Ljava/lang/Integer;
+	public final fun component62 ()Ljava/lang/Boolean;
+	public final fun component63 ()Ljava/lang/String;
+	public final fun component64 ()Ljava/lang/Boolean;
+	public final fun component65 ()Ljava/util/List;
+	public final fun component66 ()Ljava/util/List;
+	public final fun component67 ()Ljava/lang/Integer;
+	public final fun component68 ()Ljava/lang/Boolean;
+	public final fun component69 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/algolia/search/model/search/Query;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Query;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;IIILjava/lang/Object;)Lcom/algolia/search/model/search/Query;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public fun getAlternativesAsExact ()Ljava/util/List;
+	public fun getAnalytics ()Ljava/lang/Boolean;
+	public fun getAnalyticsTags ()Ljava/util/List;
+	public fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public fun getAttributesToHighlight ()Ljava/util/List;
+	public fun getAttributesToRetrieve ()Ljava/util/List;
+	public fun getAttributesToSnippet ()Ljava/util/List;
+	public fun getClickAnalytics ()Ljava/lang/Boolean;
+	public fun getDecompoundQuery ()Ljava/lang/Boolean;
+	public fun getDisableExactOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public fun getEnableABTest ()Ljava/lang/Boolean;
+	public fun getEnablePersonalization ()Ljava/lang/Boolean;
+	public fun getEnableReRanking ()Ljava/lang/Boolean;
+	public fun getEnableRules ()Ljava/lang/Boolean;
+	public fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public fun getExplainModules ()Ljava/util/List;
+	public fun getFacetFilters ()Ljava/util/List;
+	public fun getFacetingAfterDistinct ()Ljava/lang/Boolean;
+	public fun getFacets ()Ljava/util/Set;
+	public fun getFilters ()Ljava/lang/String;
+	public fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public fun getHighlightPostTag ()Ljava/lang/String;
+	public fun getHighlightPreTag ()Ljava/lang/String;
+	public fun getHitsPerPage ()Ljava/lang/Integer;
+	public fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public fun getInsideBoundingBox ()Ljava/util/List;
+	public fun getInsidePolygon ()Ljava/util/List;
+	public fun getLength ()Ljava/lang/Integer;
+	public fun getMaxFacetHits ()Ljava/lang/Integer;
+	public fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public fun getMinProximity ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public fun getMinimumAroundRadius ()Ljava/lang/Integer;
+	public fun getNaturalLanguages ()Ljava/util/List;
+	public fun getNumericFilters ()Ljava/util/List;
+	public fun getOffset ()Ljava/lang/Integer;
+	public fun getOptionalFilters ()Ljava/util/List;
+	public fun getOptionalWords ()Ljava/util/List;
+	public fun getPage ()Ljava/lang/Integer;
+	public fun getPercentileComputation ()Ljava/lang/Boolean;
+	public fun getPersonalizationImpact ()Ljava/lang/Integer;
+	public fun getQuery ()Ljava/lang/String;
+	public fun getQueryLanguages ()Ljava/util/List;
+	public fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public fun getRelevancyStrictness ()Ljava/lang/Integer;
+	public fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public fun getResponseFields ()Ljava/util/List;
+	public fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public fun getRestrictSearchableAttributes ()Ljava/util/List;
+	public fun getRuleContexts ()Ljava/util/List;
+	public fun getSimilarQuery ()Ljava/lang/String;
+	public fun getSnippetEllipsisText ()Ljava/lang/String;
+	public fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public fun getSumOrFiltersScores ()Ljava/lang/Boolean;
+	public fun getSynonyms ()Ljava/lang/Boolean;
+	public fun getTagFilters ()Ljava/util/List;
+	public fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public fun setAlternativesAsExact (Ljava/util/List;)V
+	public fun setAnalytics (Ljava/lang/Boolean;)V
+	public fun setAnalyticsTags (Ljava/util/List;)V
+	public fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public fun setAttributesToHighlight (Ljava/util/List;)V
+	public fun setAttributesToRetrieve (Ljava/util/List;)V
+	public fun setAttributesToSnippet (Ljava/util/List;)V
+	public fun setClickAnalytics (Ljava/lang/Boolean;)V
+	public fun setDecompoundQuery (Ljava/lang/Boolean;)V
+	public fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public fun setEnableABTest (Ljava/lang/Boolean;)V
+	public fun setEnablePersonalization (Ljava/lang/Boolean;)V
+	public fun setEnableReRanking (Ljava/lang/Boolean;)V
+	public fun setEnableRules (Ljava/lang/Boolean;)V
+	public fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public fun setExplainModules (Ljava/util/List;)V
+	public fun setFacetFilters (Ljava/util/List;)V
+	public fun setFacetingAfterDistinct (Ljava/lang/Boolean;)V
+	public fun setFacets (Ljava/util/Set;)V
+	public fun setFilters (Ljava/lang/String;)V
+	public fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public fun setHighlightPostTag (Ljava/lang/String;)V
+	public fun setHighlightPreTag (Ljava/lang/String;)V
+	public fun setHitsPerPage (Ljava/lang/Integer;)V
+	public fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public fun setInsideBoundingBox (Ljava/util/List;)V
+	public fun setInsidePolygon (Ljava/util/List;)V
+	public fun setLength (Ljava/lang/Integer;)V
+	public fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public fun setMinProximity (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public fun setMinimumAroundRadius (Ljava/lang/Integer;)V
+	public fun setNaturalLanguages (Ljava/util/List;)V
+	public fun setNumericFilters (Ljava/util/List;)V
+	public fun setOffset (Ljava/lang/Integer;)V
+	public fun setOptionalFilters (Ljava/util/List;)V
+	public fun setOptionalWords (Ljava/util/List;)V
+	public fun setPage (Ljava/lang/Integer;)V
+	public fun setPercentileComputation (Ljava/lang/Boolean;)V
+	public fun setPersonalizationImpact (Ljava/lang/Integer;)V
+	public fun setQuery (Ljava/lang/String;)V
+	public fun setQueryLanguages (Ljava/util/List;)V
+	public fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public fun setRelevancyStrictness (Ljava/lang/Integer;)V
+	public fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public fun setResponseFields (Ljava/util/List;)V
+	public fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public fun setRestrictSearchableAttributes (Ljava/util/List;)V
+	public fun setRuleContexts (Ljava/util/List;)V
+	public fun setSimilarQuery (Ljava/lang/String;)V
+	public fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public fun setSumOrFiltersScores (Ljava/lang/Boolean;)V
+	public fun setSynonyms (Ljava/lang/Boolean;)V
+	public fun setTagFilters (Ljava/util/List;)V
+	public fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+	public fun setUserToken (Lcom/algolia/search/model/insights/UserToken;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/Query;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/Query$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/Query$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Query;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Query;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Query$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/QueryType : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/QueryType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/QueryType$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/QueryType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/QueryType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/QueryType$Other : com/algolia/search/model/search/QueryType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/QueryType$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/QueryType$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/QueryType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/QueryType$PrefixAll : com/algolia/search/model/search/QueryType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/QueryType$PrefixAll;
+}
+
+public final class com/algolia/search/model/search/QueryType$PrefixLast : com/algolia/search/model/search/QueryType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/QueryType$PrefixLast;
+}
+
+public final class com/algolia/search/model/search/QueryType$PrefixNone : com/algolia/search/model/search/QueryType {
+	public static final field INSTANCE Lcom/algolia/search/model/search/QueryType$PrefixNone;
+}
+
+public final class com/algolia/search/model/search/RankingInfo {
+	public static final field Companion Lcom/algolia/search/model/search/RankingInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/Boolean;IIIIIIIIILcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/String;Lcom/algolia/search/model/search/Personalization;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/Boolean;IIIIIIIIILcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/String;Lcom/algolia/search/model/search/Personalization;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;IIIIIIIIILcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/String;Lcom/algolia/search/model/search/Personalization;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component10 ()I
+	public final fun component11 ()Lcom/algolia/search/model/search/MatchedGeoLocation;
+	public final fun component12 ()Lcom/algolia/search/model/search/Point;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Lcom/algolia/search/model/search/Personalization;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (Ljava/lang/Boolean;IIIIIIIIILcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/String;Lcom/algolia/search/model/search/Personalization;)Lcom/algolia/search/model/search/RankingInfo;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/RankingInfo;Ljava/lang/Boolean;IIIIIIIIILcom/algolia/search/model/search/MatchedGeoLocation;Lcom/algolia/search/model/search/Point;Ljava/lang/String;Lcom/algolia/search/model/search/Personalization;ILjava/lang/Object;)Lcom/algolia/search/model/search/RankingInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilters ()I
+	public final fun getFirstMatchedWord ()I
+	public final fun getGeoDistance ()I
+	public final fun getGeoPoint ()Lcom/algolia/search/model/search/Point;
+	public final fun getGeoPrecision ()I
+	public final fun getMatchedGeoLocation ()Lcom/algolia/search/model/search/MatchedGeoLocation;
+	public final fun getNbExactWords ()I
+	public final fun getNbTypos ()I
+	public final fun getPersonalization ()Lcom/algolia/search/model/search/Personalization;
+	public final fun getPromoted ()Ljava/lang/Boolean;
+	public final fun getProximityDistance ()I
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getUserScore ()I
+	public final fun getWords ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/RankingInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/RankingInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RankingInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/RankingInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/RankingInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/RankingInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/RecommendSearchOptions : com/algolia/search/model/params/SearchParameters {
+	public static final field Companion Lcom/algolia/search/model/search/RecommendSearchOptions$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (IIILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Set;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Lcom/algolia/search/model/search/TypoTolerance;
+	public final fun component23 ()Ljava/lang/Boolean;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Lcom/algolia/search/model/search/Point;
+	public final fun component26 ()Ljava/lang/Boolean;
+	public final fun component27 ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun component28 ()Lcom/algolia/search/model/search/AroundPrecision;
+	public final fun component29 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component30 ()Ljava/util/List;
+	public final fun component31 ()Ljava/util/List;
+	public final fun component32 ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public final fun component33 ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public final fun component34 ()Ljava/util/List;
+	public final fun component35 ()Ljava/lang/Boolean;
+	public final fun component36 ()Ljava/util/List;
+	public final fun component37 ()Ljava/lang/Boolean;
+	public final fun component38 ()Ljava/lang/Integer;
+	public final fun component39 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component40 ()Lcom/algolia/search/model/search/QueryType;
+	public final fun component41 ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public final fun component42 ()Ljava/lang/Boolean;
+	public final fun component43 ()Ljava/util/List;
+	public final fun component44 ()Ljava/util/List;
+	public final fun component45 ()Ljava/util/List;
+	public final fun component46 ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public final fun component47 ()Ljava/util/List;
+	public final fun component48 ()Lcom/algolia/search/model/settings/Distinct;
+	public final fun component49 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component50 ()Ljava/lang/Boolean;
+	public final fun component51 ()Ljava/lang/Boolean;
+	public final fun component52 ()Ljava/util/List;
+	public final fun component53 ()Ljava/lang/Boolean;
+	public final fun component54 ()Ljava/lang/Boolean;
+	public final fun component55 ()Ljava/lang/Integer;
+	public final fun component56 ()Ljava/util/List;
+	public final fun component57 ()Ljava/lang/Integer;
+	public final fun component58 ()Ljava/lang/Boolean;
+	public final fun component59 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component60 ()Ljava/lang/Boolean;
+	public final fun component61 ()Ljava/util/List;
+	public final fun component62 ()Ljava/util/List;
+	public final fun component63 ()Ljava/lang/Integer;
+	public final fun component64 ()Ljava/lang/Boolean;
+	public final fun component65 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/RecommendSearchOptions;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;IIILjava/lang/Object;)Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public fun getAlternativesAsExact ()Ljava/util/List;
+	public fun getAnalytics ()Ljava/lang/Boolean;
+	public fun getAnalyticsTags ()Ljava/util/List;
+	public fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public fun getAttributesToHighlight ()Ljava/util/List;
+	public fun getAttributesToRetrieve ()Ljava/util/List;
+	public fun getAttributesToSnippet ()Ljava/util/List;
+	public fun getClickAnalytics ()Ljava/lang/Boolean;
+	public fun getDecompoundQuery ()Ljava/lang/Boolean;
+	public fun getDisableExactOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public fun getEnableABTest ()Ljava/lang/Boolean;
+	public fun getEnablePersonalization ()Ljava/lang/Boolean;
+	public fun getEnableReRanking ()Ljava/lang/Boolean;
+	public fun getEnableRules ()Ljava/lang/Boolean;
+	public fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public fun getExplainModules ()Ljava/util/List;
+	public fun getFacetFilters ()Ljava/util/List;
+	public fun getFacetingAfterDistinct ()Ljava/lang/Boolean;
+	public fun getFacets ()Ljava/util/Set;
+	public fun getFilters ()Ljava/lang/String;
+	public fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public fun getHighlightPostTag ()Ljava/lang/String;
+	public fun getHighlightPreTag ()Ljava/lang/String;
+	public fun getHitsPerPage ()Ljava/lang/Integer;
+	public fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public fun getInsideBoundingBox ()Ljava/util/List;
+	public fun getInsidePolygon ()Ljava/util/List;
+	public fun getLength ()Ljava/lang/Integer;
+	public fun getMaxFacetHits ()Ljava/lang/Integer;
+	public fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public fun getMinProximity ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public fun getMinimumAroundRadius ()Ljava/lang/Integer;
+	public fun getNaturalLanguages ()Ljava/util/List;
+	public fun getNumericFilters ()Ljava/util/List;
+	public fun getOffset ()Ljava/lang/Integer;
+	public fun getOptionalFilters ()Ljava/util/List;
+	public fun getOptionalWords ()Ljava/util/List;
+	public fun getPage ()Ljava/lang/Integer;
+	public fun getPercentileComputation ()Ljava/lang/Boolean;
+	public fun getPersonalizationImpact ()Ljava/lang/Integer;
+	public fun getQuery ()Ljava/lang/String;
+	public fun getQueryLanguages ()Ljava/util/List;
+	public fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public fun getRelevancyStrictness ()Ljava/lang/Integer;
+	public fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public fun getResponseFields ()Ljava/util/List;
+	public fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public fun getRestrictSearchableAttributes ()Ljava/util/List;
+	public fun getRuleContexts ()Ljava/util/List;
+	public fun getSimilarQuery ()Ljava/lang/String;
+	public fun getSnippetEllipsisText ()Ljava/lang/String;
+	public fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public fun getSumOrFiltersScores ()Ljava/lang/Boolean;
+	public fun getSynonyms ()Ljava/lang/Boolean;
+	public fun getTagFilters ()Ljava/util/List;
+	public fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public fun setAlternativesAsExact (Ljava/util/List;)V
+	public fun setAnalytics (Ljava/lang/Boolean;)V
+	public fun setAnalyticsTags (Ljava/util/List;)V
+	public fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public fun setAttributesToHighlight (Ljava/util/List;)V
+	public fun setAttributesToRetrieve (Ljava/util/List;)V
+	public fun setAttributesToSnippet (Ljava/util/List;)V
+	public fun setClickAnalytics (Ljava/lang/Boolean;)V
+	public fun setDecompoundQuery (Ljava/lang/Boolean;)V
+	public fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public fun setEnableABTest (Ljava/lang/Boolean;)V
+	public fun setEnablePersonalization (Ljava/lang/Boolean;)V
+	public fun setEnableReRanking (Ljava/lang/Boolean;)V
+	public fun setEnableRules (Ljava/lang/Boolean;)V
+	public fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public fun setExplainModules (Ljava/util/List;)V
+	public fun setFacetFilters (Ljava/util/List;)V
+	public fun setFacetingAfterDistinct (Ljava/lang/Boolean;)V
+	public fun setFacets (Ljava/util/Set;)V
+	public fun setFilters (Ljava/lang/String;)V
+	public fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public fun setHighlightPostTag (Ljava/lang/String;)V
+	public fun setHighlightPreTag (Ljava/lang/String;)V
+	public fun setHitsPerPage (Ljava/lang/Integer;)V
+	public fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public fun setInsideBoundingBox (Ljava/util/List;)V
+	public fun setInsidePolygon (Ljava/util/List;)V
+	public fun setLength (Ljava/lang/Integer;)V
+	public fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public fun setMinProximity (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public fun setMinimumAroundRadius (Ljava/lang/Integer;)V
+	public fun setNaturalLanguages (Ljava/util/List;)V
+	public fun setNumericFilters (Ljava/util/List;)V
+	public fun setOffset (Ljava/lang/Integer;)V
+	public fun setOptionalFilters (Ljava/util/List;)V
+	public fun setOptionalWords (Ljava/util/List;)V
+	public fun setPage (Ljava/lang/Integer;)V
+	public fun setPercentileComputation (Ljava/lang/Boolean;)V
+	public fun setPersonalizationImpact (Ljava/lang/Integer;)V
+	public fun setQuery (Ljava/lang/String;)V
+	public fun setQueryLanguages (Ljava/util/List;)V
+	public fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public fun setRelevancyStrictness (Ljava/lang/Integer;)V
+	public fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public fun setResponseFields (Ljava/util/List;)V
+	public fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public fun setRestrictSearchableAttributes (Ljava/util/List;)V
+	public fun setRuleContexts (Ljava/util/List;)V
+	public fun setSimilarQuery (Ljava/lang/String;)V
+	public fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public fun setSumOrFiltersScores (Ljava/lang/Boolean;)V
+	public fun setSynonyms (Ljava/lang/Boolean;)V
+	public fun setTagFilters (Ljava/util/List;)V
+	public fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+	public fun setUserToken (Lcom/algolia/search/model/insights/UserToken;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/RecommendSearchOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/RecommendSearchOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RecommendSearchOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/RecommendSearchOptions;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/RecommendSearchOptions;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/RecommendSearchOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/RemoveStopWords {
+	public static final field Companion Lcom/algolia/search/model/search/RemoveStopWords$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class com/algolia/search/model/search/RemoveStopWords$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/RemoveStopWords;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/RemoveStopWords$False : com/algolia/search/model/search/RemoveStopWords {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveStopWords$False;
+}
+
+public final class com/algolia/search/model/search/RemoveStopWords$QueryLanguages : com/algolia/search/model/search/RemoveStopWords {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lcom/algolia/search/model/search/Language;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/search/RemoveStopWords$QueryLanguages;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/RemoveStopWords$QueryLanguages;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/search/RemoveStopWords$QueryLanguages;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQueryLanguages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/RemoveStopWords$True : com/algolia/search/model/search/RemoveStopWords {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveStopWords$True;
+}
+
+public abstract class com/algolia/search/model/search/RemoveWordIfNoResults : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/RemoveWordIfNoResults$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$AllOptional : com/algolia/search/model/search/RemoveWordIfNoResults {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveWordIfNoResults$AllOptional;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$FirstWords : com/algolia/search/model/search/RemoveWordIfNoResults {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveWordIfNoResults$FirstWords;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$LastWords : com/algolia/search/model/search/RemoveWordIfNoResults {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveWordIfNoResults$LastWords;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$None : com/algolia/search/model/search/RemoveWordIfNoResults {
+	public static final field INSTANCE Lcom/algolia/search/model/search/RemoveWordIfNoResults$None;
+}
+
+public final class com/algolia/search/model/search/RemoveWordIfNoResults$Other : com/algolia/search/model/search/RemoveWordIfNoResults {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/RemoveWordIfNoResults$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/RemoveWordIfNoResults$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/RemoveWordIfNoResults$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/search/ResponseFields : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/ResponseFields$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$All : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$All;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$AroundLatLng : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$AroundLatLng;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$AutomaticRadius : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$AutomaticRadius;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/ResponseFields;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/ResponseFields;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$ExhaustiveFacetsCount : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$ExhaustiveFacetsCount;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Facets : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Facets;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$FacetsStats : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$FacetsStats;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Hits : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Hits;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$HitsPerPage : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$HitsPerPage;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Index : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Index;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Length : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Length;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$NbHits : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$NbHits;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$NbPages : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$NbPages;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Offset : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Offset;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Other : com/algolia/search/model/search/ResponseFields {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/ResponseFields$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/ResponseFields$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/ResponseFields$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Page : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Page;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Params : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Params;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$ProcessingTimeMS : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$ProcessingTimeMS;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$Query : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$Query;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$QueryAfterRemoval : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$QueryAfterRemoval;
+}
+
+public final class com/algolia/search/model/search/ResponseFields$UserData : com/algolia/search/model/search/ResponseFields {
+	public static final field INSTANCE Lcom/algolia/search/model/search/ResponseFields$UserData;
+}
+
+public final class com/algolia/search/model/search/SearchParameters : com/algolia/search/model/params/CommonSearchParameters {
+	public static final field Companion Lcom/algolia/search/model/search/SearchParameters$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (IILjava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Lcom/algolia/search/model/search/TypoTolerance;
+	public final fun component23 ()Ljava/lang/Boolean;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Lcom/algolia/search/model/search/Point;
+	public final fun component26 ()Ljava/lang/Boolean;
+	public final fun component27 ()Lcom/algolia/search/model/search/AroundRadius;
+	public final fun component28 ()Lcom/algolia/search/model/search/AroundPrecision;
+	public final fun component29 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component30 ()Ljava/util/List;
+	public final fun component31 ()Ljava/util/List;
+	public final fun component32 ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public final fun component33 ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public final fun component34 ()Ljava/lang/Boolean;
+	public final fun component35 ()Ljava/util/List;
+	public final fun component36 ()Ljava/lang/Boolean;
+	public final fun component37 ()Ljava/lang/Integer;
+	public final fun component38 ()Lcom/algolia/search/model/insights/UserToken;
+	public final fun component39 ()Lcom/algolia/search/model/search/QueryType;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component40 ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public final fun component41 ()Ljava/lang/Boolean;
+	public final fun component42 ()Ljava/util/List;
+	public final fun component43 ()Ljava/util/List;
+	public final fun component44 ()Ljava/util/List;
+	public final fun component45 ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public final fun component46 ()Ljava/util/List;
+	public final fun component47 ()Lcom/algolia/search/model/settings/Distinct;
+	public final fun component48 ()Ljava/lang/Boolean;
+	public final fun component49 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component50 ()Ljava/lang/Boolean;
+	public final fun component51 ()Ljava/util/List;
+	public final fun component52 ()Ljava/lang/Boolean;
+	public final fun component53 ()Ljava/lang/Boolean;
+	public final fun component54 ()Ljava/lang/Integer;
+	public final fun component55 ()Ljava/util/List;
+	public final fun component56 ()Ljava/lang/Integer;
+	public final fun component57 ()Ljava/lang/Boolean;
+	public final fun component58 ()Ljava/lang/String;
+	public final fun component59 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component60 ()Ljava/util/List;
+	public final fun component61 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/util/Set;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;)Lcom/algolia/search/model/search/SearchParameters;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/SearchParameters;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/Integer;Ljava/lang/Boolean;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/search/Point;Ljava/lang/Boolean;Lcom/algolia/search/model/search/AroundRadius;Lcom/algolia/search/model/search/AroundPrecision;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Lcom/algolia/search/model/insights/UserToken;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lcom/algolia/search/model/search/SearchParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public fun getAlternativesAsExact ()Ljava/util/List;
+	public fun getAnalytics ()Ljava/lang/Boolean;
+	public fun getAnalyticsTags ()Ljava/util/List;
+	public fun getAroundLatLng ()Lcom/algolia/search/model/search/Point;
+	public fun getAroundLatLngViaIP ()Ljava/lang/Boolean;
+	public fun getAroundPrecision ()Lcom/algolia/search/model/search/AroundPrecision;
+	public fun getAroundRadius ()Lcom/algolia/search/model/search/AroundRadius;
+	public fun getAttributesToHighlight ()Ljava/util/List;
+	public fun getAttributesToRetrieve ()Ljava/util/List;
+	public fun getClickAnalytics ()Ljava/lang/Boolean;
+	public fun getDisableExactOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public fun getEnableABTest ()Ljava/lang/Boolean;
+	public fun getEnablePersonalization ()Ljava/lang/Boolean;
+	public fun getEnableRules ()Ljava/lang/Boolean;
+	public fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public fun getExplainModules ()Ljava/util/List;
+	public fun getFacetFilters ()Ljava/util/List;
+	public fun getFacetingAfterDistinct ()Ljava/lang/Boolean;
+	public fun getFacets ()Ljava/util/Set;
+	public fun getFilters ()Ljava/lang/String;
+	public fun getGetRankingInfo ()Ljava/lang/Boolean;
+	public fun getHighlightPostTag ()Ljava/lang/String;
+	public fun getHighlightPreTag ()Ljava/lang/String;
+	public fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public fun getInsideBoundingBox ()Ljava/util/List;
+	public fun getInsidePolygon ()Ljava/util/List;
+	public fun getLength ()Ljava/lang/Integer;
+	public fun getMaxFacetHits ()Ljava/lang/Integer;
+	public fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public fun getMinProximity ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public fun getMinimumAroundRadius ()Ljava/lang/Integer;
+	public fun getNaturalLanguages ()Ljava/util/List;
+	public fun getNumericFilters ()Ljava/util/List;
+	public fun getOffset ()Ljava/lang/Integer;
+	public fun getOptionalFilters ()Ljava/util/List;
+	public fun getOptionalWords ()Ljava/util/List;
+	public fun getPage ()Ljava/lang/Integer;
+	public fun getPercentileComputation ()Ljava/lang/Boolean;
+	public fun getPersonalizationImpact ()Ljava/lang/Integer;
+	public fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public fun getResponseFields ()Ljava/util/List;
+	public fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public fun getRuleContexts ()Ljava/util/List;
+	public fun getSimilarQuery ()Ljava/lang/String;
+	public fun getSnippetEllipsisText ()Ljava/lang/String;
+	public fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public fun getSumOrFiltersScores ()Ljava/lang/Boolean;
+	public fun getSynonyms ()Ljava/lang/Boolean;
+	public fun getTagFilters ()Ljava/util/List;
+	public fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public fun getUserToken ()Lcom/algolia/search/model/insights/UserToken;
+	public fun hashCode ()I
+	public fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public fun setAlternativesAsExact (Ljava/util/List;)V
+	public fun setAnalytics (Ljava/lang/Boolean;)V
+	public fun setAnalyticsTags (Ljava/util/List;)V
+	public fun setAroundLatLng (Lcom/algolia/search/model/search/Point;)V
+	public fun setAroundLatLngViaIP (Ljava/lang/Boolean;)V
+	public fun setAroundPrecision (Lcom/algolia/search/model/search/AroundPrecision;)V
+	public fun setAroundRadius (Lcom/algolia/search/model/search/AroundRadius;)V
+	public fun setAttributesToHighlight (Ljava/util/List;)V
+	public fun setAttributesToRetrieve (Ljava/util/List;)V
+	public fun setClickAnalytics (Ljava/lang/Boolean;)V
+	public fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public fun setEnableABTest (Ljava/lang/Boolean;)V
+	public fun setEnablePersonalization (Ljava/lang/Boolean;)V
+	public fun setEnableRules (Ljava/lang/Boolean;)V
+	public fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public fun setExplainModules (Ljava/util/List;)V
+	public fun setFacetFilters (Ljava/util/List;)V
+	public fun setFacetingAfterDistinct (Ljava/lang/Boolean;)V
+	public fun setFacets (Ljava/util/Set;)V
+	public fun setFilters (Ljava/lang/String;)V
+	public fun setGetRankingInfo (Ljava/lang/Boolean;)V
+	public fun setHighlightPostTag (Ljava/lang/String;)V
+	public fun setHighlightPreTag (Ljava/lang/String;)V
+	public fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public fun setInsideBoundingBox (Ljava/util/List;)V
+	public fun setInsidePolygon (Ljava/util/List;)V
+	public fun setLength (Ljava/lang/Integer;)V
+	public fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public fun setMinProximity (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public fun setMinimumAroundRadius (Ljava/lang/Integer;)V
+	public fun setNaturalLanguages (Ljava/util/List;)V
+	public fun setNumericFilters (Ljava/util/List;)V
+	public fun setOffset (Ljava/lang/Integer;)V
+	public fun setOptionalFilters (Ljava/util/List;)V
+	public fun setOptionalWords (Ljava/util/List;)V
+	public fun setPage (Ljava/lang/Integer;)V
+	public fun setPercentileComputation (Ljava/lang/Boolean;)V
+	public fun setPersonalizationImpact (Ljava/lang/Integer;)V
+	public fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public fun setResponseFields (Ljava/util/List;)V
+	public fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public fun setRuleContexts (Ljava/util/List;)V
+	public fun setSimilarQuery (Ljava/lang/String;)V
+	public fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public fun setSumOrFiltersScores (Ljava/lang/Boolean;)V
+	public fun setSynonyms (Ljava/lang/Boolean;)V
+	public fun setTagFilters (Ljava/util/List;)V
+	public fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+	public fun setUserToken (Lcom/algolia/search/model/insights/UserToken;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/SearchParameters;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/SearchParameters$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/SearchParameters$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/SearchParameters;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/SearchParameters;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/SearchParameters$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/Snippet : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/Snippet$Companion;
+	public fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;)Lcom/algolia/search/model/search/Snippet;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/Snippet;Lcom/algolia/search/model/Attribute;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/algolia/search/model/search/Snippet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getCount ()Ljava/lang/Integer;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/Snippet$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Snippet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Snippet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/SnippetResult {
+	public static final field Companion Lcom/algolia/search/model/search/SnippetResult$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lcom/algolia/search/model/search/MatchLevel;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/algolia/search/model/search/MatchLevel;
+	public final fun copy (Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;)Lcom/algolia/search/model/search/SnippetResult;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/SnippetResult;Ljava/lang/String;Lcom/algolia/search/model/search/MatchLevel;ILjava/lang/Object;)Lcom/algolia/search/model/search/SnippetResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMatchLevel ()Lcom/algolia/search/model/search/MatchLevel;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/search/SnippetResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/search/SnippetResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/search/SnippetResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/SnippetResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/SnippetResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/SnippetResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/search/SortFacetsBy : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/SortFacetsBy$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/SortFacetsBy$Alpha : com/algolia/search/model/search/SortFacetsBy {
+	public static final field INSTANCE Lcom/algolia/search/model/search/SortFacetsBy$Alpha;
+}
+
+public final class com/algolia/search/model/search/SortFacetsBy$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/SortFacetsBy;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/SortFacetsBy$Count : com/algolia/search/model/search/SortFacetsBy {
+	public static final field INSTANCE Lcom/algolia/search/model/search/SortFacetsBy$Count;
+}
+
+public final class com/algolia/search/model/search/SortFacetsBy$Other : com/algolia/search/model/search/SortFacetsBy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/SortFacetsBy$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/SortFacetsBy$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/SortFacetsBy$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/search/TypoTolerance : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/search/TypoTolerance$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/TypoTolerance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/TypoTolerance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$False : com/algolia/search/model/search/TypoTolerance {
+	public static final field INSTANCE Lcom/algolia/search/model/search/TypoTolerance$False;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$Min : com/algolia/search/model/search/TypoTolerance {
+	public static final field INSTANCE Lcom/algolia/search/model/search/TypoTolerance$Min;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$Other : com/algolia/search/model/search/TypoTolerance {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/search/TypoTolerance$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/search/TypoTolerance$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/search/TypoTolerance$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$Strict : com/algolia/search/model/search/TypoTolerance {
+	public static final field INSTANCE Lcom/algolia/search/model/search/TypoTolerance$Strict;
+}
+
+public final class com/algolia/search/model/search/TypoTolerance$True : com/algolia/search/model/search/TypoTolerance {
+	public static final field INSTANCE Lcom/algolia/search/model/search/TypoTolerance$True;
+}
+
+public abstract class com/algolia/search/model/settings/AdvancedSyntaxFeatures : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/AdvancedSyntaxFeatures$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/AdvancedSyntaxFeatures$ExactPhrase : com/algolia/search/model/settings/AdvancedSyntaxFeatures {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$ExactPhrase;
+}
+
+public final class com/algolia/search/model/settings/AdvancedSyntaxFeatures$ExcludeWords : com/algolia/search/model/settings/AdvancedSyntaxFeatures {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$ExcludeWords;
+}
+
+public final class com/algolia/search/model/settings/AdvancedSyntaxFeatures$Other : com/algolia/search/model/settings/AdvancedSyntaxFeatures {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/settings/AdvancedSyntaxFeatures$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/settings/AttributeForFaceting {
+	public static final field Companion Lcom/algolia/search/model/settings/AttributeForFaceting$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public abstract fun getAttribute ()Lcom/algolia/search/model/Attribute;
+}
+
+public final class com/algolia/search/model/settings/AttributeForFaceting$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/AttributeForFaceting;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/AttributeForFaceting;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/AttributeForFaceting$Default : com/algolia/search/model/settings/AttributeForFaceting {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/AttributeForFaceting$Default;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/AttributeForFaceting$Default;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/AttributeForFaceting$Default;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/AttributeForFaceting$FilterOnly : com/algolia/search/model/settings/AttributeForFaceting {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/AttributeForFaceting$FilterOnly;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/AttributeForFaceting$FilterOnly;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/AttributeForFaceting$FilterOnly;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/AttributeForFaceting$Searchable : com/algolia/search/model/settings/AttributeForFaceting {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/AttributeForFaceting$Searchable;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/AttributeForFaceting$Searchable;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/AttributeForFaceting$Searchable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/algolia/search/model/settings/CustomRankingCriterion : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/settings/CustomRankingCriterion$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/CustomRankingCriterion$Asc : com/algolia/search/model/settings/CustomRankingCriterion {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Asc;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/CustomRankingCriterion$Asc;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Asc;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/CustomRankingCriterion$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/CustomRankingCriterion;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/CustomRankingCriterion;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/CustomRankingCriterion$Desc : com/algolia/search/model/settings/CustomRankingCriterion {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Desc;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/CustomRankingCriterion$Desc;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Desc;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/CustomRankingCriterion$Other : com/algolia/search/model/settings/CustomRankingCriterion {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/CustomRankingCriterion$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/settings/CustomRankingCriterion$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/DecompoundedAttributes {
+	public static final field Companion Lcom/algolia/search/model/settings/DecompoundedAttributes$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/search/Language;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/search/Language$Dutch;[Lcom/algolia/search/model/Attribute;)V
+	public fun <init> (Lcom/algolia/search/model/search/Language$Finnish;[Lcom/algolia/search/model/Attribute;)V
+	public fun <init> (Lcom/algolia/search/model/search/Language$German;[Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/search/Language;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/search/Language;Ljava/util/List;)Lcom/algolia/search/model/settings/DecompoundedAttributes;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/DecompoundedAttributes;Lcom/algolia/search/model/search/Language;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/settings/DecompoundedAttributes;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/List;
+	public final fun getLanguage ()Lcom/algolia/search/model/search/Language;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/settings/DecompoundedAttributes;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/settings/DecompoundedAttributes$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/DecompoundedAttributes$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/DecompoundedAttributes;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/DecompoundedAttributes;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/DecompoundedAttributes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/Distinct {
+	public static final field Companion Lcom/algolia/search/model/settings/Distinct$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/algolia/search/model/settings/Distinct;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/Distinct;IILjava/lang/Object;)Lcom/algolia/search/model/settings/Distinct;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/Distinct$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/Distinct;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/Distinct;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/NumericAttributeFilter : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/settings/NumericAttributeFilter$Companion;
+	public fun <init> (Lcom/algolia/search/model/Attribute;Z)V
+	public synthetic fun <init> (Lcom/algolia/search/model/Attribute;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun component2 ()Z
+	public final fun copy (Lcom/algolia/search/model/Attribute;Z)Lcom/algolia/search/model/settings/NumericAttributeFilter;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/NumericAttributeFilter;Lcom/algolia/search/model/Attribute;ZILjava/lang/Object;)Lcom/algolia/search/model/settings/NumericAttributeFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public final fun getEqualOnly ()Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/NumericAttributeFilter$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/NumericAttributeFilter;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/NumericAttributeFilter;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/settings/RankingCriterion : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/settings/RankingCriterion$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Asc : com/algolia/search/model/settings/RankingCriterion {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/RankingCriterion$Asc;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/RankingCriterion$Asc;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/RankingCriterion$Asc;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Attribute : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Attribute;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/RankingCriterion;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/RankingCriterion;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Custom : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Custom;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Desc : com/algolia/search/model/settings/RankingCriterion {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/RankingCriterion$Desc;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/RankingCriterion$Desc;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/RankingCriterion$Desc;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Exact : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Exact;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Filters : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Filters;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Geo : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Geo;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Other : com/algolia/search/model/settings/RankingCriterion {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/settings/RankingCriterion$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/RankingCriterion$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/settings/RankingCriterion$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Proximity : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Proximity;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Typo : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Typo;
+}
+
+public final class com/algolia/search/model/settings/RankingCriterion$Words : com/algolia/search/model/settings/RankingCriterion {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/RankingCriterion$Words;
+}
+
+public abstract class com/algolia/search/model/settings/SearchableAttribute {
+	public static final field Companion Lcom/algolia/search/model/settings/SearchableAttribute$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class com/algolia/search/model/settings/SearchableAttribute$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/SearchableAttribute;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/SearchableAttribute;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/SearchableAttribute$Default : com/algolia/search/model/settings/SearchableAttribute {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/algolia/search/model/settings/SearchableAttribute$Default;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/SearchableAttribute$Default;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/settings/SearchableAttribute$Default;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/SearchableAttribute$Unordered : com/algolia/search/model/settings/SearchableAttribute {
+	public fun <init> (Lcom/algolia/search/model/Attribute;)V
+	public final fun component1 ()Lcom/algolia/search/model/Attribute;
+	public final fun copy (Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/settings/SearchableAttribute$Unordered;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/SearchableAttribute$Unordered;Lcom/algolia/search/model/Attribute;ILjava/lang/Object;)Lcom/algolia/search/model/settings/SearchableAttribute$Unordered;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Lcom/algolia/search/model/Attribute;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/Settings : com/algolia/search/model/params/SettingsParameters {
+	public static final field Companion Lcom/algolia/search/model/settings/Settings$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (IILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Ljava/util/Map;ZLjava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/rule/RenderingContent;Lcom/algolia/search/model/IndexName;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Ljava/util/Map;ZLjava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/rule/RenderingContent;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Ljava/util/Map;ZLjava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/rule/RenderingContent;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Integer;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Lcom/algolia/search/model/search/TypoTolerance;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component25 ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public final fun component26 ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public final fun component27 ()Ljava/util/List;
+	public final fun component28 ()Ljava/util/List;
+	public final fun component29 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component30 ()Ljava/util/List;
+	public final fun component31 ()Ljava/lang/Boolean;
+	public final fun component32 ()Lcom/algolia/search/model/search/QueryType;
+	public final fun component33 ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public final fun component34 ()Ljava/lang/Boolean;
+	public final fun component35 ()Ljava/util/List;
+	public final fun component36 ()Ljava/util/List;
+	public final fun component37 ()Ljava/util/List;
+	public final fun component38 ()Ljava/util/List;
+	public final fun component39 ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component40 ()Ljava/util/List;
+	public final fun component41 ()Ljava/util/List;
+	public final fun component42 ()Ljava/lang/Boolean;
+	public final fun component43 ()Lcom/algolia/search/model/Attribute;
+	public final fun component44 ()Lcom/algolia/search/model/settings/Distinct;
+	public final fun component45 ()Ljava/lang/Boolean;
+	public final fun component46 ()Ljava/lang/Integer;
+	public final fun component47 ()Ljava/util/List;
+	public final fun component48 ()Ljava/lang/Integer;
+	public final fun component49 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component50 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component51 ()Ljava/util/List;
+	public final fun component52 ()Ljava/util/Map;
+	public final fun component53 ()Z
+	public final fun component54 ()Ljava/lang/Boolean;
+	public final fun component55 ()Ljava/lang/Integer;
+	public final fun component56 ()Ljava/lang/Boolean;
+	public final fun component57 ()Ljava/util/List;
+	public final fun component58 ()Lcom/algolia/search/model/rule/RenderingContent;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Ljava/util/Map;ZLjava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/rule/RenderingContent;)Lcom/algolia/search/model/settings/Settings;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/Settings;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lcom/algolia/search/model/search/SortFacetsBy;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/algolia/search/model/search/TypoTolerance;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/algolia/search/model/search/IgnorePlurals;Lcom/algolia/search/model/search/RemoveStopWords;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/search/QueryType;Lcom/algolia/search/model/search/RemoveWordIfNoResults;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/algolia/search/model/search/ExactOnSingleWordQuery;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/algolia/search/model/Attribute;Lcom/algolia/search/model/settings/Distinct;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;Ljava/util/Map;ZLjava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lcom/algolia/search/model/rule/RenderingContent;IILjava/lang/Object;)Lcom/algolia/search/model/settings/Settings;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdvancedSyntax ()Ljava/lang/Boolean;
+	public fun getAdvancedSyntaxFeatures ()Ljava/util/List;
+	public fun getAllowCompressionOfIntegerArray ()Ljava/lang/Boolean;
+	public fun getAllowTyposOnNumericTokens ()Ljava/lang/Boolean;
+	public fun getAlternativesAsExact ()Ljava/util/List;
+	public fun getAttributeCriteriaComputedByMinProximity ()Ljava/lang/Boolean;
+	public fun getAttributeForDistinct ()Lcom/algolia/search/model/Attribute;
+	public fun getAttributesForFaceting ()Ljava/util/List;
+	public fun getAttributesToHighlight ()Ljava/util/List;
+	public fun getAttributesToRetrieve ()Ljava/util/List;
+	public fun getAttributesToSnippet ()Ljava/util/List;
+	public fun getAttributesToTransliterate ()Ljava/util/List;
+	public fun getCamelCaseAttributes ()Ljava/util/List;
+	public fun getCustomNormalization ()Ljava/util/Map;
+	public fun getCustomRanking ()Ljava/util/List;
+	public fun getDecompoundQuery ()Ljava/lang/Boolean;
+	public fun getDecompoundedAttributes ()Ljava/util/List;
+	public fun getDisableExactOnAttributes ()Ljava/util/List;
+	public fun getDisablePrefixOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnAttributes ()Ljava/util/List;
+	public fun getDisableTypoToleranceOnWords ()Ljava/util/List;
+	public fun getDistinct ()Lcom/algolia/search/model/settings/Distinct;
+	public fun getEnablePersonalization ()Z
+	public fun getEnableRules ()Ljava/lang/Boolean;
+	public fun getExactOnSingleWordQuery ()Lcom/algolia/search/model/search/ExactOnSingleWordQuery;
+	public fun getHighlightPostTag ()Ljava/lang/String;
+	public fun getHighlightPreTag ()Ljava/lang/String;
+	public fun getHitsPerPage ()Ljava/lang/Integer;
+	public fun getIgnorePlurals ()Lcom/algolia/search/model/search/IgnorePlurals;
+	public fun getIndexLanguages ()Ljava/util/List;
+	public fun getKeepDiacriticsOnCharacters ()Ljava/lang/String;
+	public fun getMaxFacetHits ()Ljava/lang/Integer;
+	public fun getMaxValuesPerFacet ()Ljava/lang/Integer;
+	public fun getMinProximity ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor1Typo ()Ljava/lang/Integer;
+	public fun getMinWordSizeFor2Typos ()Ljava/lang/Integer;
+	public fun getNumericAttributesForFiltering ()Ljava/util/List;
+	public fun getOptionalWords ()Ljava/util/List;
+	public fun getPaginationLimitedTo ()Ljava/lang/Integer;
+	public final fun getPrimary ()Lcom/algolia/search/model/IndexName;
+	public fun getQueryLanguages ()Ljava/util/List;
+	public fun getQueryType ()Lcom/algolia/search/model/search/QueryType;
+	public fun getRanking ()Ljava/util/List;
+	public fun getRelevancyStrictness ()Ljava/lang/Integer;
+	public fun getRemoveStopWords ()Lcom/algolia/search/model/search/RemoveStopWords;
+	public fun getRemoveWordsIfNoResults ()Lcom/algolia/search/model/search/RemoveWordIfNoResults;
+	public fun getRenderingContent ()Lcom/algolia/search/model/rule/RenderingContent;
+	public fun getReplaceSynonymsInHighlight ()Ljava/lang/Boolean;
+	public fun getReplicas ()Ljava/util/List;
+	public fun getResponseFields ()Ljava/util/List;
+	public fun getRestrictHighlightAndSnippetArrays ()Ljava/lang/Boolean;
+	public fun getSearchableAttributes ()Ljava/util/List;
+	public fun getSeparatorsToIndex ()Ljava/lang/String;
+	public fun getSnippetEllipsisText ()Ljava/lang/String;
+	public fun getSortFacetsBy ()Lcom/algolia/search/model/search/SortFacetsBy;
+	public fun getTypoTolerance ()Lcom/algolia/search/model/search/TypoTolerance;
+	public fun getUnretrievableAttributes ()Ljava/util/List;
+	public fun getUserData ()Lkotlinx/serialization/json/JsonObject;
+	public fun getVersion ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setAdvancedSyntax (Ljava/lang/Boolean;)V
+	public fun setAdvancedSyntaxFeatures (Ljava/util/List;)V
+	public fun setAllowCompressionOfIntegerArray (Ljava/lang/Boolean;)V
+	public fun setAllowTyposOnNumericTokens (Ljava/lang/Boolean;)V
+	public fun setAlternativesAsExact (Ljava/util/List;)V
+	public fun setAttributeCriteriaComputedByMinProximity (Ljava/lang/Boolean;)V
+	public fun setAttributeForDistinct (Lcom/algolia/search/model/Attribute;)V
+	public fun setAttributesForFaceting (Ljava/util/List;)V
+	public fun setAttributesToHighlight (Ljava/util/List;)V
+	public fun setAttributesToRetrieve (Ljava/util/List;)V
+	public fun setAttributesToSnippet (Ljava/util/List;)V
+	public fun setAttributesToTransliterate (Ljava/util/List;)V
+	public fun setCamelCaseAttributes (Ljava/util/List;)V
+	public fun setCustomNormalization (Ljava/util/Map;)V
+	public fun setCustomRanking (Ljava/util/List;)V
+	public fun setDecompoundQuery (Ljava/lang/Boolean;)V
+	public fun setDecompoundedAttributes (Ljava/util/List;)V
+	public fun setDisableExactOnAttributes (Ljava/util/List;)V
+	public fun setDisablePrefixOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnAttributes (Ljava/util/List;)V
+	public fun setDisableTypoToleranceOnWords (Ljava/util/List;)V
+	public fun setDistinct (Lcom/algolia/search/model/settings/Distinct;)V
+	public fun setEnablePersonalization (Z)V
+	public fun setEnableRules (Ljava/lang/Boolean;)V
+	public fun setExactOnSingleWordQuery (Lcom/algolia/search/model/search/ExactOnSingleWordQuery;)V
+	public fun setHighlightPostTag (Ljava/lang/String;)V
+	public fun setHighlightPreTag (Ljava/lang/String;)V
+	public fun setHitsPerPage (Ljava/lang/Integer;)V
+	public fun setIgnorePlurals (Lcom/algolia/search/model/search/IgnorePlurals;)V
+	public fun setIndexLanguages (Ljava/util/List;)V
+	public fun setKeepDiacriticsOnCharacters (Ljava/lang/String;)V
+	public fun setMaxFacetHits (Ljava/lang/Integer;)V
+	public fun setMaxValuesPerFacet (Ljava/lang/Integer;)V
+	public fun setMinProximity (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor1Typo (Ljava/lang/Integer;)V
+	public fun setMinWordSizeFor2Typos (Ljava/lang/Integer;)V
+	public fun setNumericAttributesForFiltering (Ljava/util/List;)V
+	public fun setOptionalWords (Ljava/util/List;)V
+	public fun setPaginationLimitedTo (Ljava/lang/Integer;)V
+	public fun setQueryLanguages (Ljava/util/List;)V
+	public fun setQueryType (Lcom/algolia/search/model/search/QueryType;)V
+	public fun setRanking (Ljava/util/List;)V
+	public fun setRelevancyStrictness (Ljava/lang/Integer;)V
+	public fun setRemoveStopWords (Lcom/algolia/search/model/search/RemoveStopWords;)V
+	public fun setRemoveWordsIfNoResults (Lcom/algolia/search/model/search/RemoveWordIfNoResults;)V
+	public fun setRenderingContent (Lcom/algolia/search/model/rule/RenderingContent;)V
+	public fun setReplaceSynonymsInHighlight (Ljava/lang/Boolean;)V
+	public fun setReplicas (Ljava/util/List;)V
+	public fun setResponseFields (Ljava/util/List;)V
+	public fun setRestrictHighlightAndSnippetArrays (Ljava/lang/Boolean;)V
+	public fun setSearchableAttributes (Ljava/util/List;)V
+	public fun setSeparatorsToIndex (Ljava/lang/String;)V
+	public fun setSnippetEllipsisText (Ljava/lang/String;)V
+	public fun setSortFacetsBy (Lcom/algolia/search/model/search/SortFacetsBy;)V
+	public fun setTypoTolerance (Lcom/algolia/search/model/search/TypoTolerance;)V
+	public fun setUnretrievableAttributes (Ljava/util/List;)V
+	public fun setUserData (Lkotlinx/serialization/json/JsonObject;)V
+	public fun setVersion (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/settings/Settings;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/settings/Settings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/Settings$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/settings/Settings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/settings/Settings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/settings/Settings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/settings/SettingsKey : com/algolia/search/model/internal/Raw {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AdvancedSyntax : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AdvancedSyntax;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AllowCompressionOfIntegerArray : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AllowCompressionOfIntegerArray;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AllowTyposOnNumericTokens : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AllowTyposOnNumericTokens;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AlternativesAsExact : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AlternativesAsExact;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AttributeForDistinct : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AttributeForDistinct;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AttributesForFaceting : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AttributesForFaceting;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AttributesToHighlight : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AttributesToHighlight;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AttributesToRetrieve : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AttributesToRetrieve;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$AttributesToSnippet : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$AttributesToSnippet;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$CamelCaseAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$CamelCaseAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$CustomRanking : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$CustomRanking;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$DecompoundedAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$DecompoundedAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$DisableExactOnAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$DisableExactOnAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$DisablePrefixOnAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$DisablePrefixOnAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnWords : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$DisableTypoToleranceOnWords;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$Distinct : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$Distinct;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$EnableRules : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$EnableRules;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$ExactOnSingleWordQuery : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$ExactOnSingleWordQuery;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$HighlightPostTag : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$HighlightPostTag;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$HighlightPreTag : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$HighlightPreTag;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$HitsPerPage : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$HitsPerPage;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$IgnorePlurals : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$IgnorePlurals;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$IndexLanguages : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$IndexLanguages;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$KeepDiacriticsOnCharacters : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$KeepDiacriticsOnCharacters;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$MaxFacetHits : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$MaxFacetHits;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$MaxValuesPerFacet : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$MaxValuesPerFacet;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$MinProximity : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$MinProximity;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$MinWordSizefor1Typo : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$MinWordSizefor1Typo;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$MinWordSizefor2Typos : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$MinWordSizefor2Typos;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$NumericAttributesForFiltering : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$NumericAttributesForFiltering;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$OptionalWords : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$OptionalWords;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$Other : com/algolia/search/model/settings/SettingsKey {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/settings/SettingsKey$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/settings/SettingsKey$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/settings/SettingsKey$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$PaginationLimitedTo : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$PaginationLimitedTo;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$QueryLanguages : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$QueryLanguages;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$QueryType : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$QueryType;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$Ranking : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$Ranking;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$RemoveStopWords : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$RemoveStopWords;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$RemoveWordsIfNoResults : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$RemoveWordsIfNoResults;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$ReplaceSynonymsInHighlight : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$ReplaceSynonymsInHighlight;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$Replicas : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$Replicas;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$ResponseFields : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$ResponseFields;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$RestrictHighlightAndSnippetArrays : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$RestrictHighlightAndSnippetArrays;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$SearchableAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$SearchableAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$SeparatorsToIndex : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$SeparatorsToIndex;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$SnippetEllipsisText : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$SnippetEllipsisText;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$SortFacetsBy : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$SortFacetsBy;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$TypoTolerance : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$TypoTolerance;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$UnretrievableAttributes : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$UnretrievableAttributes;
+}
+
+public final class com/algolia/search/model/settings/SettingsKey$UserData : com/algolia/search/model/settings/SettingsKey {
+	public static final field INSTANCE Lcom/algolia/search/model/settings/SettingsKey$UserData;
+}
+
+public abstract class com/algolia/search/model/synonym/Synonym {
+	public static final field Companion Lcom/algolia/search/model/synonym/Synonym$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public abstract fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$AlternativeCorrections : com/algolia/search/model/synonym/Synonym {
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;Lcom/algolia/search/model/synonym/SynonymType$Typo;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;Lcom/algolia/search/model/synonym/SynonymType$Typo;)Lcom/algolia/search/model/synonym/Synonym$AlternativeCorrections;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$AlternativeCorrections;Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;Lcom/algolia/search/model/synonym/SynonymType$Typo;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$AlternativeCorrections;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCorrections ()Ljava/util/List;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getTypo ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public final fun getWord ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/synonym/Synonym;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/synonym/Synonym;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$MultiWay : com/algolia/search/model/synonym/Synonym {
+	public static final field Companion Lcom/algolia/search/model/synonym/Synonym$MultiWay$Companion;
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Ljava/util/List;)Lcom/algolia/search/model/synonym/Synonym$MultiWay;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$MultiWay;Lcom/algolia/search/model/ObjectID;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$MultiWay;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getSynonyms ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$MultiWay$Companion {
+}
+
+public final class com/algolia/search/model/synonym/Synonym$OneWay : com/algolia/search/model/synonym/Synonym {
+	public static final field Companion Lcom/algolia/search/model/synonym/Synonym$OneWay$Companion;
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;)Lcom/algolia/search/model/synonym/Synonym$OneWay;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$OneWay;Lcom/algolia/search/model/ObjectID;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$OneWay;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInput ()Ljava/lang/String;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getSynonyms ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$OneWay$Companion {
+}
+
+public final class com/algolia/search/model/synonym/Synonym$Other : com/algolia/search/model/synonym/Synonym {
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;)Lcom/algolia/search/model/synonym/Synonym$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$Other;Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$Placeholder : com/algolia/search/model/synonym/Synonym {
+	public fun <init> (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;Ljava/util/List;)V
+	public final fun component1 ()Lcom/algolia/search/model/ObjectID;
+	public final fun component2 ()Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;Ljava/util/List;)Lcom/algolia/search/model/synonym/Synonym$Placeholder;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$Placeholder;Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$Placeholder;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getObjectID ()Lcom/algolia/search/model/ObjectID;
+	public final fun getPlaceholder ()Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;
+	public final fun getReplacements ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/Synonym$Placeholder$Token : com/algolia/search/model/internal/Raw {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/Synonym$Placeholder$Token;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/SynonymQuery {
+	public static final field Companion Lcom/algolia/search/model/synonym/SynonymQuery$Companion;
+	public static final field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;)Lcom/algolia/search/model/synonym/SynonymQuery;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/SynonymQuery;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/SynonymQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHitsPerPage ()Ljava/lang/Integer;
+	public final fun getPage ()Ljava/lang/Integer;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getSynonymTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun setHitsPerPage (Ljava/lang/Integer;)V
+	public final fun setPage (Ljava/lang/Integer;)V
+	public final fun setQuery (Ljava/lang/String;)V
+	public final fun setSynonymTypes (Ljava/util/List;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/SynonymQuery$Companion : kotlinx/serialization/KSerializer, kotlinx/serialization/SerializationStrategy {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/synonym/SynonymQuery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/synonym/SynonymQuery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/synonym/SynonymType : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/synonym/SynonymType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$AlternativeCorrections : com/algolia/search/model/synonym/SynonymType {
+	public fun <init> (Lcom/algolia/search/model/synonym/SynonymType$Typo;)V
+	public final fun component1 ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public final fun copy (Lcom/algolia/search/model/synonym/SynonymType$Typo;)Lcom/algolia/search/model/synonym/SynonymType$AlternativeCorrections;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/SynonymType$AlternativeCorrections;Lcom/algolia/search/model/synonym/SynonymType$Typo;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/SynonymType$AlternativeCorrections;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypo ()Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/synonym/SynonymType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/synonym/SynonymType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$MultiWay : com/algolia/search/model/synonym/SynonymType {
+	public static final field INSTANCE Lcom/algolia/search/model/synonym/SynonymType$MultiWay;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$OneWay : com/algolia/search/model/synonym/SynonymType {
+	public static final field INSTANCE Lcom/algolia/search/model/synonym/SynonymType$OneWay;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$Other : com/algolia/search/model/synonym/SynonymType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/synonym/SynonymType$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/synonym/SynonymType$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/synonym/SynonymType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$Placeholder : com/algolia/search/model/synonym/SynonymType {
+	public static final field INSTANCE Lcom/algolia/search/model/synonym/SynonymType$Placeholder;
+}
+
+public final class com/algolia/search/model/synonym/SynonymType$Typo : java/lang/Enum {
+	public static final field One Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public static final field Two Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public static fun valueOf (Ljava/lang/String;)Lcom/algolia/search/model/synonym/SynonymType$Typo;
+	public static fun values ()[Lcom/algolia/search/model/synonym/SynonymType$Typo;
+}
+
+public abstract interface class com/algolia/search/model/task/AppTaskID {
+	public abstract fun getRaw ()J
+}
+
+public abstract interface class com/algolia/search/model/task/DictionaryTask {
+	public abstract fun getTaskID ()Lcom/algolia/search/model/task/DictionaryTaskID;
+}
+
+public final class com/algolia/search/model/task/DictionaryTaskID : com/algolia/search/model/task/AppTaskID {
+	public static final field Companion Lcom/algolia/search/model/task/DictionaryTaskID$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/algolia/search/model/task/DictionaryTaskID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/task/DictionaryTaskID;JILjava/lang/Object;)Lcom/algolia/search/model/task/DictionaryTaskID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/task/DictionaryTaskID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/task/DictionaryTaskID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/task/DictionaryTaskID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/algolia/search/model/task/Task {
+	public abstract fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+}
+
+public final class com/algolia/search/model/task/TaskID : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/task/TaskID$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/algolia/search/model/task/TaskID;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/task/TaskID;JILjava/lang/Object;)Lcom/algolia/search/model/task/TaskID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Ljava/lang/Long;
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/task/TaskID$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/task/TaskID;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/task/TaskID;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/task/TaskIndex : com/algolia/search/model/task/Task {
+	public static final field Companion Lcom/algolia/search/model/task/TaskIndex$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/IndexName;Lcom/algolia/search/model/task/TaskID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/task/TaskID;)V
+	public final fun component1 ()Lcom/algolia/search/model/IndexName;
+	public final fun component2 ()Lcom/algolia/search/model/task/TaskID;
+	public final fun copy (Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/task/TaskID;)Lcom/algolia/search/model/task/TaskIndex;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/task/TaskIndex;Lcom/algolia/search/model/IndexName;Lcom/algolia/search/model/task/TaskID;ILjava/lang/Object;)Lcom/algolia/search/model/task/TaskIndex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexName ()Lcom/algolia/search/model/IndexName;
+	public fun getTaskID ()Lcom/algolia/search/model/task/TaskID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/task/TaskIndex;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/task/TaskIndex$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/task/TaskIndex$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/task/TaskIndex;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/task/TaskIndex;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/task/TaskIndex$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/task/TaskInfo {
+	public static final field Companion Lcom/algolia/search/model/task/TaskInfo$Companion;
+	public synthetic fun <init> (ILcom/algolia/search/model/task/TaskStatus;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/algolia/search/model/task/TaskStatus;Z)V
+	public final fun component1 ()Lcom/algolia/search/model/task/TaskStatus;
+	public final fun component2 ()Z
+	public final fun copy (Lcom/algolia/search/model/task/TaskStatus;Z)Lcom/algolia/search/model/task/TaskInfo;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/task/TaskInfo;Lcom/algolia/search/model/task/TaskStatus;ZILjava/lang/Object;)Lcom/algolia/search/model/task/TaskInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPendingTask ()Z
+	public final fun getStatus ()Lcom/algolia/search/model/task/TaskStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/algolia/search/model/task/TaskInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/algolia/search/model/task/TaskInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/algolia/search/model/task/TaskInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/task/TaskInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/task/TaskInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/task/TaskInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/algolia/search/model/task/TaskStatus : com/algolia/search/model/internal/Raw {
+	public static final field Companion Lcom/algolia/search/model/task/TaskStatus$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/task/TaskStatus$Companion : kotlinx/serialization/KSerializer {
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/task/TaskStatus;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/task/TaskStatus;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/algolia/search/model/task/TaskStatus$NotPublished : com/algolia/search/model/task/TaskStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/task/TaskStatus$NotPublished;
+}
+
+public final class com/algolia/search/model/task/TaskStatus$Other : com/algolia/search/model/task/TaskStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/algolia/search/model/task/TaskStatus$Other;
+	public static synthetic fun copy$default (Lcom/algolia/search/model/task/TaskStatus$Other;Ljava/lang/String;ILjava/lang/Object;)Lcom/algolia/search/model/task/TaskStatus$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getRaw ()Ljava/lang/Object;
+	public fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/algolia/search/model/task/TaskStatus$Published : com/algolia/search/model/task/TaskStatus {
+	public static final field INSTANCE Lcom/algolia/search/model/task/TaskStatus$Published;
+}
+
+public final class com/algolia/search/serialize/CountriesKt {
+	public static final field KeyAfghanistan Ljava/lang/String;
+	public static final field KeyAlandIslands Ljava/lang/String;
+	public static final field KeyAlbania Ljava/lang/String;
+	public static final field KeyAlgeria Ljava/lang/String;
+	public static final field KeyAmericanSamoa Ljava/lang/String;
+	public static final field KeyAndorra Ljava/lang/String;
+	public static final field KeyAngola Ljava/lang/String;
+	public static final field KeyAnguilla Ljava/lang/String;
+	public static final field KeyAntarctica Ljava/lang/String;
+	public static final field KeyAntiguaAndBarbuda Ljava/lang/String;
+	public static final field KeyArgentina Ljava/lang/String;
+	public static final field KeyArmenia Ljava/lang/String;
+	public static final field KeyAruba Ljava/lang/String;
+	public static final field KeyAustralia Ljava/lang/String;
+	public static final field KeyAustria Ljava/lang/String;
+	public static final field KeyAzerbaijan Ljava/lang/String;
+	public static final field KeyBahamas Ljava/lang/String;
+	public static final field KeyBahrain Ljava/lang/String;
+	public static final field KeyBailiwickOfGuernsey Ljava/lang/String;
+	public static final field KeyBangladesh Ljava/lang/String;
+	public static final field KeyBarbados Ljava/lang/String;
+	public static final field KeyBelarus Ljava/lang/String;
+	public static final field KeyBelgium Ljava/lang/String;
+	public static final field KeyBelize Ljava/lang/String;
+	public static final field KeyBenin Ljava/lang/String;
+	public static final field KeyBermuda Ljava/lang/String;
+	public static final field KeyBhutan Ljava/lang/String;
+	public static final field KeyBolivia Ljava/lang/String;
+	public static final field KeyBosniaAndHerzegovina Ljava/lang/String;
+	public static final field KeyBotswana Ljava/lang/String;
+	public static final field KeyBouvetIsland Ljava/lang/String;
+	public static final field KeyBrazil Ljava/lang/String;
+	public static final field KeyBritishIndianOceanTerritory Ljava/lang/String;
+	public static final field KeyBruneiDarussalam Ljava/lang/String;
+	public static final field KeyBulgaria Ljava/lang/String;
+	public static final field KeyBurkinaFaso Ljava/lang/String;
+	public static final field KeyBurundi Ljava/lang/String;
+	public static final field KeyCaboVerde Ljava/lang/String;
+	public static final field KeyCambodia Ljava/lang/String;
+	public static final field KeyCameroon Ljava/lang/String;
+	public static final field KeyCanada Ljava/lang/String;
+	public static final field KeyCaribbeanNetherlands Ljava/lang/String;
+	public static final field KeyCaymanIslands Ljava/lang/String;
+	public static final field KeyCentralAfricanRepublic Ljava/lang/String;
+	public static final field KeyChad Ljava/lang/String;
+	public static final field KeyChile Ljava/lang/String;
+	public static final field KeyChina Ljava/lang/String;
+	public static final field KeyChristmasIsland Ljava/lang/String;
+	public static final field KeyCocosIslands Ljava/lang/String;
+	public static final field KeyColombia Ljava/lang/String;
+	public static final field KeyComoros Ljava/lang/String;
+	public static final field KeyCookIslands Ljava/lang/String;
+	public static final field KeyCostaRica Ljava/lang/String;
+	public static final field KeyCroatia Ljava/lang/String;
+	public static final field KeyCuba Ljava/lang/String;
+	public static final field KeyCuracao Ljava/lang/String;
+	public static final field KeyCyprus Ljava/lang/String;
+	public static final field KeyCzechRepublic Ljava/lang/String;
+	public static final field KeyDemocraticRepublicOfTheCongo Ljava/lang/String;
+	public static final field KeyDenmark Ljava/lang/String;
+	public static final field KeyDjibouti Ljava/lang/String;
+	public static final field KeyDominica Ljava/lang/String;
+	public static final field KeyDominicanRepublic Ljava/lang/String;
+	public static final field KeyEcuador Ljava/lang/String;
+	public static final field KeyEgypt Ljava/lang/String;
+	public static final field KeyElSalvador Ljava/lang/String;
+	public static final field KeyEquatorialGuinea Ljava/lang/String;
+	public static final field KeyEritrea Ljava/lang/String;
+	public static final field KeyEstonia Ljava/lang/String;
+	public static final field KeyEswatini Ljava/lang/String;
+	public static final field KeyEthiopia Ljava/lang/String;
+	public static final field KeyFalklandIslands Ljava/lang/String;
+	public static final field KeyFaroeIslands Ljava/lang/String;
+	public static final field KeyFiji Ljava/lang/String;
+	public static final field KeyFinland Ljava/lang/String;
+	public static final field KeyFrance Ljava/lang/String;
+	public static final field KeyFrenchGuiana Ljava/lang/String;
+	public static final field KeyFrenchPolynesia Ljava/lang/String;
+	public static final field KeyFrenchSouthernAndAntarcticLands Ljava/lang/String;
+	public static final field KeyGabon Ljava/lang/String;
+	public static final field KeyGambia Ljava/lang/String;
+	public static final field KeyGeorgia Ljava/lang/String;
+	public static final field KeyGermany Ljava/lang/String;
+	public static final field KeyGhana Ljava/lang/String;
+	public static final field KeyGibraltar Ljava/lang/String;
+	public static final field KeyGreece Ljava/lang/String;
+	public static final field KeyGreenland Ljava/lang/String;
+	public static final field KeyGrenada Ljava/lang/String;
+	public static final field KeyGuadeloupe Ljava/lang/String;
+	public static final field KeyGuam Ljava/lang/String;
+	public static final field KeyGuatemala Ljava/lang/String;
+	public static final field KeyGuinea Ljava/lang/String;
+	public static final field KeyGuineaBissau Ljava/lang/String;
+	public static final field KeyGuyana Ljava/lang/String;
+	public static final field KeyHaiti Ljava/lang/String;
+	public static final field KeyHeardIslandAndMcDonaldIslands Ljava/lang/String;
+	public static final field KeyHonduras Ljava/lang/String;
+	public static final field KeyHongKong Ljava/lang/String;
+	public static final field KeyHungary Ljava/lang/String;
+	public static final field KeyIceland Ljava/lang/String;
+	public static final field KeyIndia Ljava/lang/String;
+	public static final field KeyIndonesia Ljava/lang/String;
+	public static final field KeyIran Ljava/lang/String;
+	public static final field KeyIraq Ljava/lang/String;
+	public static final field KeyIreland Ljava/lang/String;
+	public static final field KeyIsleOfMan Ljava/lang/String;
+	public static final field KeyIsrael Ljava/lang/String;
+	public static final field KeyItaly Ljava/lang/String;
+	public static final field KeyIvoryCoast Ljava/lang/String;
+	public static final field KeyJamaica Ljava/lang/String;
+	public static final field KeyJapan Ljava/lang/String;
+	public static final field KeyJersey Ljava/lang/String;
+	public static final field KeyJordan Ljava/lang/String;
+	public static final field KeyKazakhstan Ljava/lang/String;
+	public static final field KeyKenya Ljava/lang/String;
+	public static final field KeyKiribati Ljava/lang/String;
+	public static final field KeyKuwait Ljava/lang/String;
+	public static final field KeyKyrgyzstan Ljava/lang/String;
+	public static final field KeyLaos Ljava/lang/String;
+	public static final field KeyLatvia Ljava/lang/String;
+	public static final field KeyLebanon Ljava/lang/String;
+	public static final field KeyLesotho Ljava/lang/String;
+	public static final field KeyLiberia Ljava/lang/String;
+	public static final field KeyLibya Ljava/lang/String;
+	public static final field KeyLiechtenstein Ljava/lang/String;
+	public static final field KeyLithuania Ljava/lang/String;
+	public static final field KeyLuxembourg Ljava/lang/String;
+	public static final field KeyMacau Ljava/lang/String;
+	public static final field KeyMadagascar Ljava/lang/String;
+	public static final field KeyMalawi Ljava/lang/String;
+	public static final field KeyMalaysia Ljava/lang/String;
+	public static final field KeyMaldives Ljava/lang/String;
+	public static final field KeyMali Ljava/lang/String;
+	public static final field KeyMalta Ljava/lang/String;
+	public static final field KeyMarshallIslands Ljava/lang/String;
+	public static final field KeyMartinique Ljava/lang/String;
+	public static final field KeyMauritania Ljava/lang/String;
+	public static final field KeyMauritius Ljava/lang/String;
+	public static final field KeyMayotte Ljava/lang/String;
+	public static final field KeyMexico Ljava/lang/String;
+	public static final field KeyMicronesia Ljava/lang/String;
+	public static final field KeyMoldova Ljava/lang/String;
+	public static final field KeyMonaco Ljava/lang/String;
+	public static final field KeyMongolia Ljava/lang/String;
+	public static final field KeyMontenegro Ljava/lang/String;
+	public static final field KeyMontserrat Ljava/lang/String;
+	public static final field KeyMorocco Ljava/lang/String;
+	public static final field KeyMozambique Ljava/lang/String;
+	public static final field KeyMyanmar Ljava/lang/String;
+	public static final field KeyNamibia Ljava/lang/String;
+	public static final field KeyNauru Ljava/lang/String;
+	public static final field KeyNepal Ljava/lang/String;
+	public static final field KeyNetherlands Ljava/lang/String;
+	public static final field KeyNewCaledonia Ljava/lang/String;
+	public static final field KeyNewZealand Ljava/lang/String;
+	public static final field KeyNicaragua Ljava/lang/String;
+	public static final field KeyNiger Ljava/lang/String;
+	public static final field KeyNigeria Ljava/lang/String;
+	public static final field KeyNiue Ljava/lang/String;
+	public static final field KeyNorfolkIsland Ljava/lang/String;
+	public static final field KeyNorthKorea Ljava/lang/String;
+	public static final field KeyNorthMacedonia Ljava/lang/String;
+	public static final field KeyNorthernMarianaIslands Ljava/lang/String;
+	public static final field KeyNorway Ljava/lang/String;
+	public static final field KeyOman Ljava/lang/String;
+	public static final field KeyPakistan Ljava/lang/String;
+	public static final field KeyPalau Ljava/lang/String;
+	public static final field KeyPalestine Ljava/lang/String;
+	public static final field KeyPanama Ljava/lang/String;
+	public static final field KeyPapuaNewGuinea Ljava/lang/String;
+	public static final field KeyParaguay Ljava/lang/String;
+	public static final field KeyPeru Ljava/lang/String;
+	public static final field KeyPhilippines Ljava/lang/String;
+	public static final field KeyPitcairnIslands Ljava/lang/String;
+	public static final field KeyPoland Ljava/lang/String;
+	public static final field KeyPortugal Ljava/lang/String;
+	public static final field KeyPuertoRico Ljava/lang/String;
+	public static final field KeyQatar Ljava/lang/String;
+	public static final field KeyRepublicOfTheCongo Ljava/lang/String;
+	public static final field KeyReunion Ljava/lang/String;
+	public static final field KeyRomania Ljava/lang/String;
+	public static final field KeyRussia Ljava/lang/String;
+	public static final field KeyRwanda Ljava/lang/String;
+	public static final field KeySaintBarthelemy Ljava/lang/String;
+	public static final field KeySaintHelena Ljava/lang/String;
+	public static final field KeySaintKittsAndNevis Ljava/lang/String;
+	public static final field KeySaintLucia Ljava/lang/String;
+	public static final field KeySaintMartin Ljava/lang/String;
+	public static final field KeySaintPierreAndMiquelon Ljava/lang/String;
+	public static final field KeySaintVincentAndTheGrenadines Ljava/lang/String;
+	public static final field KeySamoa Ljava/lang/String;
+	public static final field KeySanMarino Ljava/lang/String;
+	public static final field KeySaoTomeAndPrincipe Ljava/lang/String;
+	public static final field KeySaudiArabia Ljava/lang/String;
+	public static final field KeySenegal Ljava/lang/String;
+	public static final field KeySerbia Ljava/lang/String;
+	public static final field KeySeychelles Ljava/lang/String;
+	public static final field KeySierraLeone Ljava/lang/String;
+	public static final field KeySingapore Ljava/lang/String;
+	public static final field KeySintMaarten Ljava/lang/String;
+	public static final field KeySlovakia Ljava/lang/String;
+	public static final field KeySlovenia Ljava/lang/String;
+	public static final field KeySolomonIslands Ljava/lang/String;
+	public static final field KeySomalia Ljava/lang/String;
+	public static final field KeySouthAfrica Ljava/lang/String;
+	public static final field KeySouthGeorgiaAndTheSouthSandwichIslands Ljava/lang/String;
+	public static final field KeySouthKorea Ljava/lang/String;
+	public static final field KeySouthSudan Ljava/lang/String;
+	public static final field KeySpain Ljava/lang/String;
+	public static final field KeySriLanka Ljava/lang/String;
+	public static final field KeySudan Ljava/lang/String;
+	public static final field KeySuriname Ljava/lang/String;
+	public static final field KeySvalbardAndJanMayen Ljava/lang/String;
+	public static final field KeySweden Ljava/lang/String;
+	public static final field KeySwitzerland Ljava/lang/String;
+	public static final field KeySyria Ljava/lang/String;
+	public static final field KeyTaiwan Ljava/lang/String;
+	public static final field KeyTajikistan Ljava/lang/String;
+	public static final field KeyTanzania Ljava/lang/String;
+	public static final field KeyThailand Ljava/lang/String;
+	public static final field KeyTimorLeste Ljava/lang/String;
+	public static final field KeyTogo Ljava/lang/String;
+	public static final field KeyTokelau Ljava/lang/String;
+	public static final field KeyTonga Ljava/lang/String;
+	public static final field KeyTrinidadAndTobago Ljava/lang/String;
+	public static final field KeyTunisia Ljava/lang/String;
+	public static final field KeyTurkey Ljava/lang/String;
+	public static final field KeyTurkmenistan Ljava/lang/String;
+	public static final field KeyTurksAndCaicosIslands Ljava/lang/String;
+	public static final field KeyTuvalu Ljava/lang/String;
+	public static final field KeyUganda Ljava/lang/String;
+	public static final field KeyUkraine Ljava/lang/String;
+	public static final field KeyUnitedArabEmirates Ljava/lang/String;
+	public static final field KeyUnitedKingdom Ljava/lang/String;
+	public static final field KeyUnitedStates Ljava/lang/String;
+	public static final field KeyUnitedStatesMinorOutlyingIslands Ljava/lang/String;
+	public static final field KeyUruguay Ljava/lang/String;
+	public static final field KeyUzbekistan Ljava/lang/String;
+	public static final field KeyVanuatu Ljava/lang/String;
+	public static final field KeyVaticanCity Ljava/lang/String;
+	public static final field KeyVenezuela Ljava/lang/String;
+	public static final field KeyVietnam Ljava/lang/String;
+	public static final field KeyVirginIslandsGB Ljava/lang/String;
+	public static final field KeyVirginIslandsUS Ljava/lang/String;
+	public static final field KeyWallisAndFutuna Ljava/lang/String;
+	public static final field KeyWesternSahara Ljava/lang/String;
+	public static final field KeyYemen Ljava/lang/String;
+	public static final field KeyZambia Ljava/lang/String;
+	public static final field KeyZimbabwe Ljava/lang/String;
+}
+
+public final class com/algolia/search/serialize/DeserializerKt {
+	public static final fun toHighlight (Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/search/HighlightResult;
+	public static final fun toHighlight (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lcom/algolia/search/model/search/HighlightResult;
+	public static final fun toHighlights (Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/Attribute;)Ljava/util/List;
+	public static final fun toHighlights (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Ljava/util/List;
+	public static final fun toSnippet (Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/Attribute;)Lcom/algolia/search/model/search/SnippetResult;
+	public static final fun toSnippet (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lcom/algolia/search/model/search/SnippetResult;
+	public static final fun toSnippets (Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/model/Attribute;)Ljava/util/List;
+	public static final fun toSnippets (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class com/algolia/search/serialize/KSerializerClientDate : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerClientDate;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/ClientDate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/ClientDate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerDecompoundedAttributes : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerDecompoundedAttributes;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerFacetList : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerFacetList;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerFacetMap : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerFacetMap;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/Map;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/Map;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerGeoDistance : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerGeoDistance;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Integer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;I)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerGeoPoint : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerGeoPoint;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Point;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Point;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerGeoPoints : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerGeoPoints;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerObjectIDs : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerObjectIDs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerPoint : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerPoint;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/search/Point;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/search/Point;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/serialize/KSerializerVariant : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/algolia/search/serialize/KSerializerVariant;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/algolia/search/model/analytics/Variant;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/algolia/search/model/analytics/Variant;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/algolia/search/serialize/KeysOneKt {
+	public static final field KeyAction Ljava/lang/String;
+	public static final field KeyAdd Ljava/lang/String;
+	public static final field KeyAddObject Ljava/lang/String;
+	public static final field KeyAddUnique Ljava/lang/String;
+	public static final field KeyAdvancedSyntax Ljava/lang/String;
+	public static final field KeyAlgoliaUserID Ljava/lang/String;
+	public static final field KeyAll Ljava/lang/String;
+	public static final field KeyAllOptional Ljava/lang/String;
+	public static final field KeyAllowCompressionOfIntegerArray Ljava/lang/String;
+	public static final field KeyAllowTyposOnNumericTokens Ljava/lang/String;
+	public static final field KeyAlpha Ljava/lang/String;
+	public static final field KeyAlternativeCorrection1 Ljava/lang/String;
+	public static final field KeyAlternativeCorrection2 Ljava/lang/String;
+	public static final field KeyAlternativesAsExact Ljava/lang/String;
+	public static final field KeyAnalytics Ljava/lang/String;
+	public static final field KeyAnalyticsTags Ljava/lang/String;
+	public static final field KeyAnchoring Ljava/lang/String;
+	public static final field KeyAroundLatLng Ljava/lang/String;
+	public static final field KeyAroundLatLngViaIP Ljava/lang/String;
+	public static final field KeyAroundPrecision Ljava/lang/String;
+	public static final field KeyAroundRadius Ljava/lang/String;
+	public static final field KeyAsc Ljava/lang/String;
+	public static final field KeyAttribute Ljava/lang/String;
+	public static final field KeyAttributeForDistinct Ljava/lang/String;
+	public static final field KeyAttributesForFaceting Ljava/lang/String;
+	public static final field KeyAttributesToHighlight Ljava/lang/String;
+	public static final field KeyAttributesToRetrieve Ljava/lang/String;
+	public static final field KeyAttributesToSnippet Ljava/lang/String;
+	public static final field KeyAutomaticFacetFilters Ljava/lang/String;
+	public static final field KeyAutomaticOptionalFacetFilters Ljava/lang/String;
+	public static final field KeyAutomaticRadius Ljava/lang/String;
+	public static final field KeyBody Ljava/lang/String;
+	public static final field KeyBrowse Ljava/lang/String;
+	public static final field KeyCamelCaseAttributes Ljava/lang/String;
+	public static final field KeyClear Ljava/lang/String;
+	public static final field KeyClearExistingRules Ljava/lang/String;
+	public static final field KeyClickAnalytics Ljava/lang/String;
+	public static final field KeyCluster Ljava/lang/String;
+	public static final field KeyContains Ljava/lang/String;
+	public static final field KeyContext Ljava/lang/String;
+	public static final field KeyCopy Ljava/lang/String;
+	public static final field KeyCorrections Ljava/lang/String;
+	public static final field KeyCount Ljava/lang/String;
+	public static final field KeyCreateIfNotExists Ljava/lang/String;
+	public static final field KeyCreatedAt Ljava/lang/String;
+	public static final field KeyCursor Ljava/lang/String;
+	public static final field KeyCustom Ljava/lang/String;
+	public static final field KeyCustomRanking Ljava/lang/String;
+	public static final field KeyDecompoundedAttributes Ljava/lang/String;
+	public static final field KeyDecrement Ljava/lang/String;
+	public static final field KeyDelete Ljava/lang/String;
+	public static final field KeyDeleteIndex Ljava/lang/String;
+	public static final field KeyDeleteObject Ljava/lang/String;
+	public static final field KeyDeletedAt Ljava/lang/String;
+	public static final field KeyDesc Ljava/lang/String;
+	public static final field KeyDestination Ljava/lang/String;
+	public static final field KeyDisableExactOnAttributes Ljava/lang/String;
+	public static final field KeyDisablePrefixOnAttributes Ljava/lang/String;
+	public static final field KeyDisableTypoToleranceOnAttributes Ljava/lang/String;
+	public static final field KeyDisableTypoToleranceOnWords Ljava/lang/String;
+	public static final field KeyDisjunctive Ljava/lang/String;
+	public static final field KeyDistinct Ljava/lang/String;
+	public static final field KeyEditSettings Ljava/lang/String;
+	public static final field KeyEdits Ljava/lang/String;
+	public static final field KeyEnablePersonalization Ljava/lang/String;
+	public static final field KeyEnableRules Ljava/lang/String;
+	public static final field KeyEndsWith Ljava/lang/String;
+	public static final field KeyEqualOnly Ljava/lang/String;
+	public static final field KeyExact Ljava/lang/String;
+	public static final field KeyExactOnSingleWordQuery Ljava/lang/String;
+	public static final field KeyExhaustiveFacetsCount Ljava/lang/String;
+	public static final field KeyFacet Ljava/lang/String;
+	public static final field KeyFacetFilters Ljava/lang/String;
+	public static final field KeyFacetQuery Ljava/lang/String;
+	public static final field KeyFacetingAfterDistinct Ljava/lang/String;
+	public static final field KeyFacets Ljava/lang/String;
+	public static final field KeyFacets_Stats Ljava/lang/String;
+	public static final field KeyFilters Ljava/lang/String;
+	public static final field KeyFirstWords Ljava/lang/String;
+	public static final field KeyForwardToReplicas Ljava/lang/String;
+	public static final field KeyForwardedFor Ljava/lang/String;
+	public static final field KeyFull Ljava/lang/String;
+	public static final field KeyGeo Ljava/lang/String;
+	public static final field KeyGetRankingInfo Ljava/lang/String;
+	public static final field KeyHide Ljava/lang/String;
+	public static final field KeyHighlightPostTag Ljava/lang/String;
+	public static final field KeyHighlightPreTag Ljava/lang/String;
+	public static final field KeyHits Ljava/lang/String;
+	public static final field KeyHitsPerPage Ljava/lang/String;
+	public static final field KeyIgnorePlurals Ljava/lang/String;
+	public static final field KeyIncrement Ljava/lang/String;
+	public static final field KeyIncrementFrom Ljava/lang/String;
+	public static final field KeyIncrementSet Ljava/lang/String;
+	public static final field KeyIndex Ljava/lang/String;
+	public static final field KeyIndexName Ljava/lang/String;
+	public static final field KeyInput Ljava/lang/String;
+	public static final field KeyInsert Ljava/lang/String;
+	public static final field KeyInsideBoundingBox Ljava/lang/String;
+	public static final field KeyInsidePolygon Ljava/lang/String;
+	public static final field KeyIs Ljava/lang/String;
+	public static final field KeyKeepDiacriticsOnCharacters Ljava/lang/String;
+	public static final field KeyKey Ljava/lang/String;
+	public static final field KeyLastWords Ljava/lang/String;
+	public static final field KeyLength Ljava/lang/String;
+	public static final field KeyListIndexes Ljava/lang/String;
+	public static final field KeyLogs Ljava/lang/String;
+	public static final field KeyMaxFacetHits Ljava/lang/String;
+	public static final field KeyMaxValuesPerFacet Ljava/lang/String;
+	public static final field KeyMin Ljava/lang/String;
+	public static final field KeyMinProximity Ljava/lang/String;
+	public static final field KeyMinWordSizeFor1Typo Ljava/lang/String;
+	public static final field KeyMinWordSizeFor2Typos Ljava/lang/String;
+	public static final field KeyMinimumAroundRadius Ljava/lang/String;
+	public static final field KeyMove Ljava/lang/String;
+	public static final field KeyMultiWordsSynonym Ljava/lang/String;
+	public static final field KeyNbHits Ljava/lang/String;
+	public static final field KeyNbPages Ljava/lang/String;
+	public static final field KeyNone Ljava/lang/String;
+	public static final field KeyNotPublished Ljava/lang/String;
+	public static final field KeyNumericAttributesForFiltering Ljava/lang/String;
+	public static final field KeyNumericFilters Ljava/lang/String;
+	public static final field KeyObjectID Ljava/lang/String;
+	public static final field KeyObjectIDs Ljava/lang/String;
+	public static final field KeyOffset Ljava/lang/String;
+	public static final field KeyOneWaySynonym Ljava/lang/String;
+	public static final field KeyOperation Ljava/lang/String;
+	public static final field KeyOptionalFilters Ljava/lang/String;
+	public static final field KeyOptionalWords Ljava/lang/String;
+	public static final field KeyPage Ljava/lang/String;
+	public static final field KeyPaginationLimitedTo Ljava/lang/String;
+	public static final field KeyParams Ljava/lang/String;
+	public static final field KeyPartial Ljava/lang/String;
+	public static final field KeyPartialUpdateObject Ljava/lang/String;
+	public static final field KeyPartialUpdateObjectNoCreate Ljava/lang/String;
+	public static final field KeyPattern Ljava/lang/String;
+	public static final field KeyPercentileComputation Ljava/lang/String;
+	public static final field KeyPlaceholder Ljava/lang/String;
+	public static final field KeyPrefixAll Ljava/lang/String;
+	public static final field KeyPrefixLast Ljava/lang/String;
+	public static final field KeyPrefixNone Ljava/lang/String;
+	public static final field KeyProcessingTimeMS Ljava/lang/String;
+	public static final field KeyPromote Ljava/lang/String;
+	public static final field KeyProximity Ljava/lang/String;
+	public static final field KeyPublished Ljava/lang/String;
+	public static final field KeyQuery Ljava/lang/String;
+	public static final field KeyQueryAfterRemoval Ljava/lang/String;
+	public static final field KeyQueryLanguages Ljava/lang/String;
+	public static final field KeyQueryType Ljava/lang/String;
+	public static final field KeyRanking Ljava/lang/String;
+	public static final field KeyRemove Ljava/lang/String;
+	public static final field KeyRemoveLowercase Ljava/lang/String;
+	public static final field KeyRemoveStopWords Ljava/lang/String;
+	public static final field KeyRemoveWordsIfNoResults Ljava/lang/String;
+	public static final field KeyReplace Ljava/lang/String;
+	public static final field KeyReplaceExistingSynonyms Ljava/lang/String;
+	public static final field KeyReplaceSynonymsInHighlight Ljava/lang/String;
+	public static final field KeyReplacements Ljava/lang/String;
+	public static final field KeyReplicas Ljava/lang/String;
+	public static final field KeyRequests Ljava/lang/String;
+	public static final field KeyResponseFields Ljava/lang/String;
+	public static final field KeyRestrictHighlightAndSnippetArrays Ljava/lang/String;
+	public static final field KeyRestrictSearchableAttributes Ljava/lang/String;
+	public static final field KeyResults Ljava/lang/String;
+	public static final field KeyRule Ljava/lang/String;
+	public static final field KeyRuleContexts Ljava/lang/String;
+	public static final field KeyRules Ljava/lang/String;
+	public static final field KeyScope Ljava/lang/String;
+	public static final field KeyScore Ljava/lang/String;
+	public static final field KeySearch Ljava/lang/String;
+	public static final field KeySearchableAttributes Ljava/lang/String;
+	public static final field KeySeeUnretrievableAttributes Ljava/lang/String;
+	public static final field KeySeparatorsToIndex Ljava/lang/String;
+	public static final field KeySettings Ljava/lang/String;
+	public static final field KeySingleWordSynonym Ljava/lang/String;
+	public static final field KeySnippetEllipsisText Ljava/lang/String;
+	public static final field KeySortFacetValuesBy Ljava/lang/String;
+	public static final field KeyStar Ljava/lang/String;
+	public static final field KeyStartsWith Ljava/lang/String;
+	public static final field KeyStatus Ljava/lang/String;
+	public static final field KeyStopIfEnoughMatches Ljava/lang/String;
+	public static final field KeyStrategy Ljava/lang/String;
+	public static final field KeyStrict Ljava/lang/String;
+	public static final field KeySumOrFiltersScores Ljava/lang/String;
+	public static final field KeySynonym Ljava/lang/String;
+	public static final field KeySynonyms Ljava/lang/String;
+	public static final field KeyTagFilters Ljava/lang/String;
+	public static final field KeyTaskID Ljava/lang/String;
+	public static final field KeyType Ljava/lang/String;
+	public static final field KeyTypo Ljava/lang/String;
+	public static final field KeyTypoTolerance Ljava/lang/String;
+	public static final field KeyUnretrievableAttributes Ljava/lang/String;
+	public static final field KeyUpdateObject Ljava/lang/String;
+	public static final field KeyUpdatedAt Ljava/lang/String;
+	public static final field KeyUserData Ljava/lang/String;
+	public static final field KeyValue Ljava/lang/String;
+	public static final field KeyWord Ljava/lang/String;
+	public static final field KeyWords Ljava/lang/String;
+	public static final field Key_Operation Ljava/lang/String;
+}
+
+public final class com/algolia/search/serialize/KeysThreeKt {
+	public static final field KeyAddEntry Ljava/lang/String;
+	public static final field KeyAppliedRelevancyStrictness Ljava/lang/String;
+	public static final field KeyAppliedRules Ljava/lang/String;
+	public static final field KeyAttributeCriteriaComputedByMinProximity Ljava/lang/String;
+	public static final field KeyAttributesForPrediction Ljava/lang/String;
+	public static final field KeyAttributesToTransliterate Ljava/lang/String;
+	public static final field KeyClearExistingDictionaryEntries Ljava/lang/String;
+	public static final field KeyCompounds Ljava/lang/String;
+	public static final field KeyDecomposition Ljava/lang/String;
+	public static final field KeyDecompoundQuery Ljava/lang/String;
+	public static final field KeyDefault Ljava/lang/String;
+	public static final field KeyDeleteEntry Ljava/lang/String;
+	public static final field KeyDisabled Ljava/lang/String;
+	public static final field KeyEnableReRanking Ljava/lang/String;
+	public static final field KeyExtract Ljava/lang/String;
+	public static final field KeyExtractAttribute Ljava/lang/String;
+	public static final field KeyFacetOrdering Ljava/lang/String;
+	public static final field KeyFallbackParameters Ljava/lang/String;
+	public static final field KeyFiltersScore Ljava/lang/String;
+	public static final field KeyHidden Ljava/lang/String;
+	public static final field KeyLastEventAt Ljava/lang/String;
+	public static final field KeyMaxRecommendations Ljava/lang/String;
+	public static final field KeyModel Ljava/lang/String;
+	public static final field KeyNbSortedHits Ljava/lang/String;
+	public static final field KeyOrder Ljava/lang/String;
+	public static final field KeyPlurals Ljava/lang/String;
+	public static final field KeyRelevancyStrictness Ljava/lang/String;
+	public static final field KeyRenderingContent Ljava/lang/String;
+	public static final field KeyScores Ljava/lang/String;
+	public static final field KeySortRemainingBy Ljava/lang/String;
+	public static final field KeyState Ljava/lang/String;
+	public static final field KeyStopwords Ljava/lang/String;
+	public static final field KeyThreshold Ljava/lang/String;
+	public static final field KeyValues Ljava/lang/String;
+	public static final field Key_Answer Ljava/lang/String;
+	public static final field Key_Score Ljava/lang/String;
+}
+
+public final class com/algolia/search/serialize/KeysTwoKt {
+	public static final field KeyABTest Ljava/lang/String;
+	public static final field KeyABTestID Ljava/lang/String;
+	public static final field KeyABTests Ljava/lang/String;
+	public static final field KeyAbTestVariantID Ljava/lang/String;
+	public static final field KeyAcl Ljava/lang/String;
+	public static final field KeyActive Ljava/lang/String;
+	public static final field KeyAddress Ljava/lang/String;
+	public static final field KeyAdmin_Level Ljava/lang/String;
+	public static final field KeyAdministrative Ljava/lang/String;
+	public static final field KeyAdvancedSyntaxFeatures Ljava/lang/String;
+	public static final field KeyAirport Ljava/lang/String;
+	public static final field KeyAlgoliaAPIKey Ljava/lang/String;
+	public static final field KeyAlgoliaApplicationID Ljava/lang/String;
+	public static final field KeyAltcorrection Ljava/lang/String;
+	public static final field KeyAlternatives Ljava/lang/String;
+	public static final field KeyAnswer Ljava/lang/String;
+	public static final field KeyAnswer_Code Ljava/lang/String;
+	public static final field KeyAttributesToIndex Ljava/lang/String;
+	public static final field KeyAverageClickPosition Ljava/lang/String;
+	public static final field KeyAvg Ljava/lang/String;
+	public static final field KeyBuild Ljava/lang/String;
+	public static final field KeyBusStop Ljava/lang/String;
+	public static final field KeyCity Ljava/lang/String;
+	public static final field KeyClick Ljava/lang/String;
+	public static final field KeyClickCount Ljava/lang/String;
+	public static final field KeyClickSignificance Ljava/lang/String;
+	public static final field KeyClickThroughRate Ljava/lang/String;
+	public static final field KeyClusterName Ljava/lang/String;
+	public static final field KeyClusters Ljava/lang/String;
+	public static final field KeyCompound Ljava/lang/String;
+	public static final field KeyConcat Ljava/lang/String;
+	public static final field KeyCondition Ljava/lang/String;
+	public static final field KeyConditions Ljava/lang/String;
+	public static final field KeyConsequence Ljava/lang/String;
+	public static final field KeyConversion Ljava/lang/String;
+	public static final field KeyConversionCount Ljava/lang/String;
+	public static final field KeyConversionRate Ljava/lang/String;
+	public static final field KeyConversionSignificance Ljava/lang/String;
+	public static final field KeyCountries Ljava/lang/String;
+	public static final field KeyCountry Ljava/lang/String;
+	public static final field KeyCountryCode Ljava/lang/String;
+	public static final field KeyCounty Ljava/lang/String;
+	public static final field KeyCustomNormalization Ljava/lang/String;
+	public static final field KeyCustomSearchParameters Ljava/lang/String;
+	public static final field KeyDE Ljava/lang/String;
+	public static final field KeyDataSize Ljava/lang/String;
+	public static final field KeyDegradedQuery Ljava/lang/String;
+	public static final field KeyDescription Ljava/lang/String;
+	public static final field KeyDisjunctiveFacets Ljava/lang/String;
+	public static final field KeyDistance Ljava/lang/String;
+	public static final field KeyDistrict Ljava/lang/String;
+	public static final field KeyEU Ljava/lang/String;
+	public static final field KeyEnableABTest Ljava/lang/String;
+	public static final field KeyEnabled Ljava/lang/String;
+	public static final field KeyEndAt Ljava/lang/String;
+	public static final field KeyEntries Ljava/lang/String;
+	public static final field KeyError Ljava/lang/String;
+	public static final field KeyEventName Ljava/lang/String;
+	public static final field KeyEventType Ljava/lang/String;
+	public static final field KeyEvents Ljava/lang/String;
+	public static final field KeyEventsScoring Ljava/lang/String;
+	public static final field KeyExactPhrase Ljava/lang/String;
+	public static final field KeyExcludeWords Ljava/lang/String;
+	public static final field KeyExcluded Ljava/lang/String;
+	public static final field KeyExhaustiveNbHits Ljava/lang/String;
+	public static final field KeyExpired Ljava/lang/String;
+	public static final field KeyExplain Ljava/lang/String;
+	public static final field KeyFacetHits Ljava/lang/String;
+	public static final field KeyFacetName Ljava/lang/String;
+	public static final field KeyFacetsScoring Ljava/lang/String;
+	public static final field KeyFailed Ljava/lang/String;
+	public static final field KeyFileSize Ljava/lang/String;
+	public static final field KeyFilterOnly Ljava/lang/String;
+	public static final field KeyFilterPromotes Ljava/lang/String;
+	public static final field KeyFirstMatchedWord Ljava/lang/String;
+	public static final field KeyFrom Ljava/lang/String;
+	public static final field KeyFullyHighlighted Ljava/lang/String;
+	public static final field KeyGeoDistance Ljava/lang/String;
+	public static final field KeyGeoPoint Ljava/lang/String;
+	public static final field KeyGeoPrecision Ljava/lang/String;
+	public static final field KeyGetClusters Ljava/lang/String;
+	public static final field KeyHierarchicalFacets Ljava/lang/String;
+	public static final field KeyHighlighted Ljava/lang/String;
+	public static final field KeyId Ljava/lang/String;
+	public static final field KeyImportance Ljava/lang/String;
+	public static final field KeyIndexLanguages Ljava/lang/String;
+	public static final field KeyIndexUsed Ljava/lang/String;
+	public static final field KeyIndex_Name Ljava/lang/String;
+	public static final field KeyIndexes Ljava/lang/String;
+	public static final field KeyInner_Queries Ljava/lang/String;
+	public static final field KeyIp Ljava/lang/String;
+	public static final field KeyIs_City Ljava/lang/String;
+	public static final field KeyIs_Country Ljava/lang/String;
+	public static final field KeyIs_Highway Ljava/lang/String;
+	public static final field KeyIs_Popular Ljava/lang/String;
+	public static final field KeyIs_Suburb Ljava/lang/String;
+	public static final field KeyItems Ljava/lang/String;
+	public static final field KeyKeys Ljava/lang/String;
+	public static final field KeyLanguage Ljava/lang/String;
+	public static final field KeyLastBuildTimeS Ljava/lang/String;
+	public static final field KeyLat Ljava/lang/String;
+	public static final field KeyLimit Ljava/lang/String;
+	public static final field KeyLng Ljava/lang/String;
+	public static final field KeyLocaleNames Ljava/lang/String;
+	public static final field KeyMatch Ljava/lang/String;
+	public static final field KeyMatchAlternatives Ljava/lang/String;
+	public static final field KeyMatchLevel Ljava/lang/String;
+	public static final field KeyMatchedGeoLocation Ljava/lang/String;
+	public static final field KeyMatchedWords Ljava/lang/String;
+	public static final field KeyMax Ljava/lang/String;
+	public static final field KeyMaxHitsPerQuery Ljava/lang/String;
+	public static final field KeyMaxQueriesPerIPPerHour Ljava/lang/String;
+	public static final field KeyMessage Ljava/lang/String;
+	public static final field KeyMethod Ljava/lang/String;
+	public static final field KeyName Ljava/lang/String;
+	public static final field KeyNaturalLanguages Ljava/lang/String;
+	public static final field KeyNbExactWords Ljava/lang/String;
+	public static final field KeyNbRecords Ljava/lang/String;
+	public static final field KeyNbTypos Ljava/lang/String;
+	public static final field KeyNbUserIDs Ljava/lang/String;
+	public static final field KeyNb_Api_Calls Ljava/lang/String;
+	public static final field KeyNoResultCount Ljava/lang/String;
+	public static final field KeyNumberOfPendingTasks Ljava/lang/String;
+	public static final field KeyNumericAttributesToIndex Ljava/lang/String;
+	public static final field KeyOptional Ljava/lang/String;
+	public static final field KeyOrdered Ljava/lang/String;
+	public static final field KeyOriginal Ljava/lang/String;
+	public static final field KeyParsedQuery Ljava/lang/String;
+	public static final field KeyPending Ljava/lang/String;
+	public static final field KeyPendingTask Ljava/lang/String;
+	public static final field KeyPercentage Ljava/lang/String;
+	public static final field KeyPersonalization Ljava/lang/String;
+	public static final field KeyPersonalizationImpact Ljava/lang/String;
+	public static final field KeyPlural Ljava/lang/String;
+	public static final field KeyPopulation Ljava/lang/String;
+	public static final field KeyPosition Ljava/lang/String;
+	public static final field KeyPositions Ljava/lang/String;
+	public static final field KeyPostCode Ljava/lang/String;
+	public static final field KeyPrimary Ljava/lang/String;
+	public static final field KeyProcessed Ljava/lang/String;
+	public static final field KeyProcessing_Time_Ms Ljava/lang/String;
+	public static final field KeyPromoted Ljava/lang/String;
+	public static final field KeyProximityDistance Ljava/lang/String;
+	public static final field KeyQueryID Ljava/lang/String;
+	public static final field KeyQueryParameters Ljava/lang/String;
+	public static final field KeyQuery_Body Ljava/lang/String;
+	public static final field KeyQuery_Headers Ljava/lang/String;
+	public static final field KeyQuery_ID Ljava/lang/String;
+	public static final field KeyQuery_Nb_Hits Ljava/lang/String;
+	public static final field KeyQuery_Params Ljava/lang/String;
+	public static final field KeyRankingScore Ljava/lang/String;
+	public static final field KeyReferers Ljava/lang/String;
+	public static final field KeyRestrictSources Ljava/lang/String;
+	public static final field KeySearchCount Ljava/lang/String;
+	public static final field KeySearchable Ljava/lang/String;
+	public static final field KeyServerUsed Ljava/lang/String;
+	public static final field KeySha1 Ljava/lang/String;
+	public static final field KeySimilarQuery Ljava/lang/String;
+	public static final field KeySlaves Ljava/lang/String;
+	public static final field KeySourceABTest Ljava/lang/String;
+	public static final field KeySplit Ljava/lang/String;
+	public static final field KeyStopWord Ljava/lang/String;
+	public static final field KeyStopped Ljava/lang/String;
+	public static final field KeySuburb Ljava/lang/String;
+	public static final field KeySum Ljava/lang/String;
+	public static final field KeyTimestamp Ljava/lang/String;
+	public static final field KeyTopUsers Ljava/lang/String;
+	public static final field KeyTotal Ljava/lang/String;
+	public static final field KeyTownhall Ljava/lang/String;
+	public static final field KeyTrackedSearchCount Ljava/lang/String;
+	public static final field KeyTrafficPercentage Ljava/lang/String;
+	public static final field KeyTrainStation Ljava/lang/String;
+	public static final field KeyTypes Ljava/lang/String;
+	public static final field KeyTypos Ljava/lang/String;
+	public static final field KeyUS Ljava/lang/String;
+	public static final field KeyUnordered Ljava/lang/String;
+	public static final field KeyUntil Ljava/lang/String;
+	public static final field KeyUrl Ljava/lang/String;
+	public static final field KeyUserCount Ljava/lang/String;
+	public static final field KeyUserID Ljava/lang/String;
+	public static final field KeyUserIDs Ljava/lang/String;
+	public static final field KeyUserScore Ljava/lang/String;
+	public static final field KeyUserToken Ljava/lang/String;
+	public static final field KeyUser_Token Ljava/lang/String;
+	public static final field KeyUsers Ljava/lang/String;
+	public static final field KeyValidity Ljava/lang/String;
+	public static final field KeyVariants Ljava/lang/String;
+	public static final field KeyVersion Ljava/lang/String;
+	public static final field KeyView Ljava/lang/String;
+	public static final field KeyVillage Ljava/lang/String;
+	public static final field Key_DistinctSeqID Ljava/lang/String;
+	public static final field Key_Exhaustive_Faceting Ljava/lang/String;
+	public static final field Key_Exhaustive_Nb_Hits Ljava/lang/String;
+	public static final field Key_Geoloc Ljava/lang/String;
+	public static final field Key_HighlightResult Ljava/lang/String;
+	public static final field Key_RankingInfo Ljava/lang/String;
+	public static final field Key_SnippetResult Ljava/lang/String;
+	public static final field Key_Tags Ljava/lang/String;
+}
+
+public final class com/algolia/search/serialize/LanguagesKt {
+	public static final field KeyAfrikaans Ljava/lang/String;
+	public static final field KeyAlbanian Ljava/lang/String;
+	public static final field KeyArabic Ljava/lang/String;
+	public static final field KeyArmenian Ljava/lang/String;
+	public static final field KeyAzeri Ljava/lang/String;
+	public static final field KeyBasque Ljava/lang/String;
+	public static final field KeyBrunei Ljava/lang/String;
+	public static final field KeyBulgarian Ljava/lang/String;
+	public static final field KeyCatalan Ljava/lang/String;
+	public static final field KeyCzech Ljava/lang/String;
+	public static final field KeyDanish Ljava/lang/String;
+	public static final field KeyDutch Ljava/lang/String;
+	public static final field KeyEnglish Ljava/lang/String;
+	public static final field KeyEsperanto Ljava/lang/String;
+	public static final field KeyEstonian Ljava/lang/String;
+	public static final field KeyFaroese Ljava/lang/String;
+	public static final field KeyFinnish Ljava/lang/String;
+	public static final field KeyFrench Ljava/lang/String;
+	public static final field KeyGalician Ljava/lang/String;
+	public static final field KeyGeorgian Ljava/lang/String;
+	public static final field KeyGerman Ljava/lang/String;
+	public static final field KeyHebrew Ljava/lang/String;
+	public static final field KeyHindi Ljava/lang/String;
+	public static final field KeyHungarian Ljava/lang/String;
+	public static final field KeyIcelandic Ljava/lang/String;
+	public static final field KeyIndonesian Ljava/lang/String;
+	public static final field KeyItalian Ljava/lang/String;
+	public static final field KeyJapanese Ljava/lang/String;
+	public static final field KeyKazakh Ljava/lang/String;
+	public static final field KeyKorean Ljava/lang/String;
+	public static final field KeyKyrgyz Ljava/lang/String;
+	public static final field KeyLithuanian Ljava/lang/String;
+	public static final field KeyMalay Ljava/lang/String;
+	public static final field KeyMaltese Ljava/lang/String;
+	public static final field KeyMaori Ljava/lang/String;
+	public static final field KeyMarathi Ljava/lang/String;
+	public static final field KeyMongolian Ljava/lang/String;
+	public static final field KeyNorthernSotho Ljava/lang/String;
+	public static final field KeyNorwegian Ljava/lang/String;
+	public static final field KeyPashto Ljava/lang/String;
+	public static final field KeyPolish Ljava/lang/String;
+	public static final field KeyPortuguese Ljava/lang/String;
+	public static final field KeyQuechua Ljava/lang/String;
+	public static final field KeyRomanian Ljava/lang/String;
+	public static final field KeyRussian Ljava/lang/String;
+	public static final field KeySlovak Ljava/lang/String;
+	public static final field KeySpanish Ljava/lang/String;
+	public static final field KeySwahili Ljava/lang/String;
+	public static final field KeySwedish Ljava/lang/String;
+	public static final field KeyTagalog Ljava/lang/String;
+	public static final field KeyTamil Ljava/lang/String;
+	public static final field KeyTatar Ljava/lang/String;
+	public static final field KeyTelugu Ljava/lang/String;
+	public static final field KeyTswana Ljava/lang/String;
+	public static final field KeyTurkish Ljava/lang/String;
+	public static final field KeyWelsh Ljava/lang/String;
+}
+
+public final class com/algolia/search/serialize/RoutesKt {
+	public static final field RouteABTestsV2 Ljava/lang/String;
+	public static final field RouteClustersV1 Ljava/lang/String;
+	public static final field RouteDictionaries Ljava/lang/String;
+	public static final field RouteEventsV1 Ljava/lang/String;
+	public static final field RouteIndexesV1 Ljava/lang/String;
+	public static final field RouteKeysV1 Ljava/lang/String;
+	public static final field RouteLogs Ljava/lang/String;
+	public static final field RoutePersonalization Ljava/lang/String;
+	public static final field RoutePlaces Ljava/lang/String;
+	public static final field RouteProfiles Ljava/lang/String;
+	public static final field RouteRecommendation Ljava/lang/String;
+	public static final field RouteRecommendationV2 Ljava/lang/String;
+	public static final field RouteRules Ljava/lang/String;
+	public static final field RouteSettings Ljava/lang/String;
+	public static final field RouteSynonyms Ljava/lang/String;
+	public static final field RouteTask Ljava/lang/String;
+}
+
+public final class com/algolia/search/transport/RequestOptions {
+	public fun <init> ()V
+	public final fun getBody ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getReadTimeout ()Ljava/lang/Long;
+	public final fun getUrlParameters ()Ljava/util/Map;
+	public final fun getWriteTimeout ()Ljava/lang/Long;
+	public final fun header (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun headerAlgoliaUserId (Lcom/algolia/search/model/multicluster/UserID;)V
+	public final fun headerForwardedFor (Ljava/lang/String;)V
+	public final fun parameter (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun setBody (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setReadTimeout (Ljava/lang/Long;)V
+	public final fun setWriteTimeout (Ljava/lang/Long;)V
+}
+

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("plugin.serialization")
     id("com.vanniktech.maven.publish")
     id("com.diffplug.spotless")
+    id("binary-compatibility-validator")
 }
 
 kotlin {

--- a/client/src/commonMain/kotlin/com/algolia/search/configuration/internal/ConfigurationInsightsImpl.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/configuration/internal/ConfigurationInsightsImpl.kt
@@ -14,7 +14,7 @@ import io.ktor.client.features.logging.LogLevel
 /**
  * Implementation of [ConfigurationInsights].
  */
-public data class ConfigurationInsightsImpl(
+internal data class ConfigurationInsightsImpl(
     override val applicationID: ApplicationID,
     override val apiKey: APIKey,
     override val writeTimeout: Long,

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointInsightsUser.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointInsightsUser.kt
@@ -13,7 +13,7 @@ import com.algolia.search.model.insights.InsightsEvent
 import com.algolia.search.model.insights.UserToken
 import io.ktor.client.statement.HttpResponse
 
-public class EndpointInsightsUserImpl(
+internal class EndpointInsightsUserImpl(
     private val insights: EndpointInsights,
     private val userToken: UserToken,
 ) : EndpointInsightsUser {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Add [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator):
> The tool allows to dump binary API of a Kotlin library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that make this change binary incompatible.