### PR TITLE
fix: use POST for subsequent browse

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointSearch.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointSearch.kt
@@ -4,7 +4,6 @@ package com.algolia.search.endpoint.internal
 
 import com.algolia.search.configuration.CallType
 import com.algolia.search.dsl.filters
-import com.algolia.search.dsl.internal.requestOptionsBuilder
 import com.algolia.search.endpoint.EndpointSearch
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.IndexName
@@ -22,7 +21,6 @@ import com.algolia.search.model.search.Cursor
 import com.algolia.search.model.search.Facet
 import com.algolia.search.model.search.FacetStats
 import com.algolia.search.model.search.Query
-import com.algolia.search.serialize.KeyCursor
 import com.algolia.search.serialize.KeyFacetQuery
 import com.algolia.search.serialize.internal.JsonNoDefaults
 import com.algolia.search.serialize.internal.merge

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointSearch.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointSearch.kt
@@ -11,6 +11,7 @@ import com.algolia.search.model.IndexName
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.FilterGroup
 import com.algolia.search.model.filter.FilterGroupsConverter
+import com.algolia.search.model.internal.request.RequestCursor
 import com.algolia.search.model.internal.request.RequestParams
 import com.algolia.search.model.multipleindex.IndexQuery
 import com.algolia.search.model.response.ResponseHitWithPosition
@@ -70,11 +71,10 @@ internal class EndpointSearchImpl(
     }
 
     override suspend fun browse(cursor: Cursor, requestOptions: RequestOptions?): ResponseSearch {
-        val options = requestOptionsBuilder(requestOptions) {
-            parameter(KeyCursor, cursor)
-        }
+        val params = RequestCursor(cursor.toString())
+        val body = JsonNoDefaults.encodeToString(RequestCursor.serializer(), params)
 
-        return transport.request(HttpMethod.Get, CallType.Read, indexName.toPath("/browse"), options)
+        return transport.request(HttpMethod.Post, CallType.Read, indexName.toPath("/browse"), requestOptions, body)
     }
 
     override suspend fun searchForFacets(

--- a/client/src/commonMain/kotlin/com/algolia/search/model/internal/request/RequestCursor.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/internal/request/RequestCursor.kt
@@ -1,0 +1,10 @@
+package com.algolia.search.model.internal.request
+
+import com.algolia.search.serialize.KeyCursor
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class RequestCursor(
+    @SerialName(KeyCursor) val params: String? = null
+)

--- a/client/src/commonMain/kotlin/com/algolia/search/model/internal/request/RequestCursor.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/internal/request/RequestCursor.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class RequestCursor(
-    @SerialName(KeyCursor) val params: String? = null
+    @SerialName(KeyCursor) val cursor: String? = null
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | no
| Need Doc update   | no


## Describe your change
- use [Browse index (POST)](https://www.algolia.com/doc/rest-api/search/#browse-index-post) in while loop in browseObjects instead of [Browse index (GET)](https://www.algolia.com/doc/rest-api/search/#browse-index-get)

## What problem is this fixing?
When use [Browse Index API](https://www.algolia.com/doc/rest-api/search/#browse-index-post) with long filter string, it returns long cursor.
As a result, `index.browseObjects` fails with error `invalid: 414 Request-URI Too Large` because `index.browseObjects` append cursor parameter in URL.


## To Reproduce 🔍
example code (which uses Index.partialUpdateObjects):

```
package algoliasearch.client.kotlin.example

import com.algolia.search.client.ClientSearch
import com.algolia.search.model.*
import com.algolia.search.model.search.Query
import com.algolia.search.serialize.KeyObjectID
import kotlinx.coroutines.runBlocking
import kotlinx.serialization.json.buildJsonObject
import kotlinx.serialization.json.put


fun initializeIndex() {
    val client = ClientSearch(
        applicationID = ApplicationID("application-id"),
        apiKey = APIKey("api-key")
    )

    val indexName = IndexName("test_index")

    val index = client.initIndex(indexName)

    val json = (1..1001)
        .map {buildJsonObject {
            put(KeyObjectID, it)
        }}.toList()

    runBlocking {
        index.saveObjects(json)
    }
}



fun main() {

    initializeIndex()

    val client = ClientSearch(
        applicationID = ApplicationID("application-id"),
        apiKey = APIKey("api-key")
    )
    val indexName = IndexName("test_index")

    val index = client.initIndex(indexName)

    val query = Query(
        filters = (1..1001).toList().joinToString(" OR ") { "objectID:${it}" },
        attributesToRetrieve = listOf(
            Attribute(KeyObjectID)
        )
    )
    runBlocking {
        index.browseObjects(query)
    }
}
```

Full code is available on https://github.com/tyrwzl/algoliasearch-client-kotlin-example

output
```
Exception in thread "main" io.ktor.client.features.ClientRequestException: Client request(https://APPID-dsn.algolia.net/1/indexes/test_index/browse?cursor=AtnzAWF0dHJ...) invalid: 414 Request-URI Too Large. Text: "{"message":"request uri is too large.","status":414}"
	at io.ktor.client.features.DefaultResponseValidationKt$addDefaultResponseValidation$1$1.invokeSuspend(DefaultResponseValidation.kt:47)
	at io.ktor.client.features.DefaultResponseValidationKt$addDefaultResponseValidation$1$1.invoke(DefaultResponseValidation.kt)
	at io.ktor.client.features.DefaultResponseValidationKt$addDefaultResponseValidation$1$1.invoke(DefaultResponseValidation.kt)
	at io.ktor.client.features.HttpCallValidator.validateResponse(HttpCallValidator.kt:54)
	at io.ktor.client.features.HttpCallValidator.access$validateResponse(HttpCallValidator.kt:33)
	at io.ktor.client.features.HttpCallValidator$Companion$install$3.invokeSuspend(HttpCallValidator.kt:133)
	at io.ktor.client.features.HttpCallValidator$Companion$install$3.invoke(HttpCallValidator.kt)
	at io.ktor.client.features.HttpCallValidator$Companion$install$3.invoke(HttpCallValidator.kt)
	at io.ktor.client.features.HttpSend$Feature$install$1.invokeSuspend(HttpSend.kt:96)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:191)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:147)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:15)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:93)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:277)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:87)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:61)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:40)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at algoliasearch.client.kotlin.example.MainKt.main(Main.kt:55)
	at algoliasearch.client.kotlin.example.MainKt.main(Main.kt)
```