### PR TITLE
fix: default value for `FacetOrdering.values`

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetOrdering.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetOrdering.kt
@@ -15,5 +15,5 @@ public data class FacetOrdering(
     /**
      * The ordering of facet values, within an individual list.
      */
-    @SerialName(KeyValues) public val values: Map<Attribute, FacetValuesOrder>
+    @SerialName(KeyValues) public val values: Map<Attribute, FacetValuesOrder> = emptyMap()
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #322
| Need Doc update   | no


## Describe your change

Sets default value `emptyMap` for `FacetOrdering.values`.
