### PR TITLE
fix(search): facet stats `average` and `sum` as nullable

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/search/FacetStats.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/search/FacetStats.kt
@@ -26,9 +26,9 @@ public data class FacetStats(
     /**
      * The average facet value in the result set.
      */
-    @SerialName(KeyAvg) val average: Float,
+    @SerialName(KeyAvg) val average: Float? = null,
     /**
      * The sum of all values in the result set.
      */
-    @SerialName(KeySum) val sum: Float
+    @SerialName(KeySum) val sum: Float? = null
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

`FacetStats`'s properties `average` and `sum` can be nullable; this change reflects this expected behavior.