### PR TITLE
fix: transport requests to throw `AlgoliaRuntimeException`s

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/client/ClientAccount.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/client/ClientAccount.kt
@@ -1,9 +1,9 @@
 package com.algolia.search.client
 
 import com.algolia.search.client.internal.IndexImpl
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.ApplicationID
 import com.algolia.search.model.task.Task
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
 
 /**
@@ -27,8 +27,8 @@ public object ClientAccount {
         var hasThrown404 = false
         try {
             destination.getSettings()
-        } catch (exception: ResponseException) {
-            hasThrown404 = exception.response.status.value == HttpStatusCode.NotFound.value
+        } catch (exception: AlgoliaApiException) {
+            hasThrown404 = exception.httpErrorCode == HttpStatusCode.NotFound.value
             if (!hasThrown404) throw exception
         }
         if (!hasThrown404) {

--- a/client/src/commonMain/kotlin/com/algolia/search/client/internal/ClientSearchImpl.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/client/internal/ClientSearchImpl.kt
@@ -16,6 +16,7 @@ import com.algolia.search.endpoint.internal.EndpointAPIKey
 import com.algolia.search.endpoint.internal.EndpointDictionary
 import com.algolia.search.endpoint.internal.EndpointMulticluster
 import com.algolia.search.endpoint.internal.EndpointMultipleIndex
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.IndexName
 import com.algolia.search.model.LogType
 import com.algolia.search.model.response.ResponseAPIKey
@@ -36,7 +37,6 @@ import com.algolia.search.serialize.RouteTask
 import com.algolia.search.transport.CustomRequester
 import com.algolia.search.transport.RequestOptions
 import com.algolia.search.transport.internal.Transport
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.TimeoutCancellationException
@@ -104,8 +104,8 @@ internal class ClientSearchImpl internal constructor(
             while (true) {
                 try {
                     return getAPIKey(apiKey)
-                } catch (exception: ResponseException) {
-                    if (exception.response.status.value != HttpStatusCode.NotFound.value) throw exception
+                } catch (exception: AlgoliaApiException) {
+                    if (exception.httpErrorCode != HttpStatusCode.NotFound.value) throw exception
                 }
                 delay(1000L)
             }
@@ -126,8 +126,8 @@ internal class ClientSearchImpl internal constructor(
             while (true) {
                 try {
                     getAPIKey(apiKey)
-                } catch (exception: ResponseException) {
-                    if (exception.response.status.value == HttpStatusCode.NotFound.value) return true else throw exception
+                } catch (exception: AlgoliaApiException) {
+                    if (exception.httpErrorCode == HttpStatusCode.NotFound.value) return true else throw exception
                 }
                 delay(1000L)
             }

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointIndex.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointIndex.kt
@@ -4,6 +4,7 @@ package com.algolia.search.endpoint.internal
 
 import com.algolia.search.configuration.CallType
 import com.algolia.search.endpoint.EndpointIndex
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.IndexName
 import com.algolia.search.model.index.Scope
 import com.algolia.search.model.internal.request.RequestCopyOrMove
@@ -15,7 +16,6 @@ import com.algolia.search.serialize.KeyMove
 import com.algolia.search.serialize.internal.JsonNoDefaults
 import com.algolia.search.transport.RequestOptions
 import com.algolia.search.transport.internal.Transport
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 
@@ -67,8 +67,8 @@ internal class EndpointIndexImpl(
     override suspend fun exists(): Boolean {
         try {
             EndpointSearch(transport, indexName).search(Query(responseFields = emptyList()))
-        } catch (exception: ResponseException) {
-            if (exception.response.status == HttpStatusCode.NotFound) return false
+        } catch (exception: AlgoliaApiException) {
+            if (exception.httpErrorCode == HttpStatusCode.NotFound.value) return false
         }
         return true
     }

--- a/client/src/commonMain/kotlin/com/algolia/search/exception/AlgoliaRuntimeException.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/exception/AlgoliaRuntimeException.kt
@@ -22,7 +22,6 @@ public class AlgoliaClientException(
     cause: Throwable? = null
 ) : AlgoliaRuntimeException(message, cause)
 
-
 /**
  * Exception thrown in case of API failure.
  *

--- a/client/src/commonMain/kotlin/com/algolia/search/exception/AlgoliaRuntimeException.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/exception/AlgoliaRuntimeException.kt
@@ -1,10 +1,40 @@
 package com.algolia.search.exception
 
 /**
- * Exception thrown when an error occurs during the Serialization/Deserialization process.
+ * Algolia runtime exception.
+ *
+ * @param message the detail message
+ * @param cause the cause of the exception
  */
-public sealed class AlgoliaRuntimeException(message: String? = null, cause: Throwable? = null) :
-    RuntimeException(message, cause)
+public sealed class AlgoliaRuntimeException(
+    message: String? = null,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)
+
+/**
+ * Exception thrown when an error occurs during API requests.
+ *
+ * @param message the detail message
+ * @param cause the cause of the exception
+ */
+public class AlgoliaClientException(
+    message: String? = null,
+    cause: Throwable? = null
+) : AlgoliaRuntimeException(message, cause)
+
+
+/**
+ * Exception thrown in case of API failure.
+ *
+ * @param message the detail message
+ * @param cause the cause of the exception
+ * @param httpErrorCode
+ */
+public class AlgoliaApiException(
+    message: String? = null,
+    cause: Throwable? = null,
+    public val httpErrorCode: Int? = null
+) : AlgoliaRuntimeException(message, cause)
 
 /**
  * Exception thrown when all hosts are unreachable.
@@ -14,7 +44,4 @@ public sealed class AlgoliaRuntimeException(message: String? = null, cause: Thro
  */
 public class UnreachableHostsException(
     public val exceptions: List<Throwable>,
-) : AlgoliaRuntimeException("Unreachable Hosts", exceptions.last()) {
-
-    public constructor(vararg exceptions: Throwable) : this(exceptions.toList())
-}
+) : AlgoliaRuntimeException("Error(s) while processing the retry strategy", exceptions.last())

--- a/client/src/commonMain/kotlin/com/algolia/search/exception/internal/Throwable.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/exception/internal/Throwable.kt
@@ -1,0 +1,20 @@
+package com.algolia.search.exception.internal
+
+import com.algolia.search.exception.AlgoliaApiException
+import com.algolia.search.exception.AlgoliaClientException
+import com.algolia.search.exception.AlgoliaRuntimeException
+import io.ktor.client.features.ResponseException
+
+/**
+ * Coerce a Throwable to a [AlgoliaClientException].
+ */
+internal fun Throwable.asClientException(): AlgoliaClientException {
+    return AlgoliaClientException(message = message, cause = cause)
+}
+
+/**
+ * Coerce a [ResponseException] to a [AlgoliaRuntimeException].
+ */
+internal fun ResponseException.asApiException(): AlgoliaApiException {
+    return AlgoliaApiException(message = message, cause = cause, httpErrorCode = response.status.value)
+}

--- a/client/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
@@ -88,7 +88,11 @@ internal class Transport(
     }
 
     private suspend fun genericRequest(
-        httpMethod: HttpMethod, callType: CallType, path: String, requestOptions: RequestOptions?, body: String? = null
+        httpMethod: HttpMethod,
+        callType: CallType,
+        path: String,
+        requestOptions: RequestOptions?,
+        body: String? = null
     ): HttpResponse {
         return execute(httpMethod, callType, path, requestOptions, body) {
             httpClient.request(it)

--- a/client/src/commonTest/kotlin/configuration/TestUserAgent.kt
+++ b/client/src/commonTest/kotlin/configuration/TestUserAgent.kt
@@ -4,15 +4,11 @@ import com.algolia.search.client.ClientSearch
 import com.algolia.search.configuration.AlgoliaSearchClient
 import com.algolia.search.configuration.ConfigurationSearch
 import com.algolia.search.configuration.clientUserAgent
-import com.algolia.search.dsl.requestOptions
-import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.internal.BuildConfig
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.ApplicationID
 import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respondBadRequest
 import io.ktor.client.engine.mock.respondOk
-import io.ktor.client.features.ResponseException
 import io.ktor.client.features.UserAgent
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.request
@@ -20,7 +16,6 @@ import io.ktor.client.statement.HttpResponse
 import runBlocking
 import shouldBeTrue
 import shouldEqual
-import shouldFailWith
 import kotlin.test.Test
 
 internal class TestUserAgent {

--- a/client/src/commonTest/kotlin/configuration/TestUserAgent.kt
+++ b/client/src/commonTest/kotlin/configuration/TestUserAgent.kt
@@ -5,6 +5,7 @@ import com.algolia.search.configuration.AlgoliaSearchClient
 import com.algolia.search.configuration.ConfigurationSearch
 import com.algolia.search.configuration.clientUserAgent
 import com.algolia.search.dsl.requestOptions
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.internal.BuildConfig
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.ApplicationID
@@ -54,28 +55,6 @@ internal class TestUserAgent {
 
             headers.contains(userAgentKey).shouldBeTrue()
             headers[userAgentKey] shouldEqual clientUserAgent(BuildConfig.version)
-        }
-    }
-
-    @Test
-    fun overridingUserAgentInRequestOptionsShouldNotBeIgnored() {
-        runBlocking {
-            val expected = "My User Agent"
-            val configuration = ConfigurationSearch(
-                applicationID = applicationID,
-                engine = MockEngine {
-                    respondBadRequest()
-                },
-                apiKey = apiKey
-            )
-            val client = ClientSearch(configuration)
-            val requestOptions = requestOptions { header(userAgentKey, expected) }
-            val request = shouldFailWith<ResponseException> {
-                client.listIndices(requestOptions)
-            }
-            val headers = request.response.call.request.headers
-
-            headers.get(userAgentKey) shouldEqual expected
         }
     }
 }

--- a/client/src/commonTest/kotlin/documentation/methods/synonym/DocCopySynonyms.kt
+++ b/client/src/commonTest/kotlin/documentation/methods/synonym/DocCopySynonyms.kt
@@ -1,12 +1,12 @@
 package documentation.methods.synonym
 
+import com.algolia.search.exception.AlgoliaApiException
 import documentation.index
 import documentation.indexName
-import io.ktor.client.features.ResponseException
-import runBlocking
-import shouldFailWith
 import kotlin.test.Ignore
 import kotlin.test.Test
+import runBlocking
+import shouldFailWith
 
 @Ignore
 internal class DocCopySynonyms {
@@ -18,7 +18,7 @@ internal class DocCopySynonyms {
 
     @Test
     fun snippet1() {
-        shouldFailWith<ResponseException> {
+        shouldFailWith<AlgoliaApiException> {
             runBlocking {
                 index.copySynonyms(indexName)
             }

--- a/client/src/commonTest/kotlin/documentation/methods/synonym/DocCopySynonyms.kt
+++ b/client/src/commonTest/kotlin/documentation/methods/synonym/DocCopySynonyms.kt
@@ -3,10 +3,10 @@ package documentation.methods.synonym
 import com.algolia.search.exception.AlgoliaApiException
 import documentation.index
 import documentation.indexName
-import kotlin.test.Ignore
-import kotlin.test.Test
 import runBlocking
 import shouldFailWith
+import kotlin.test.Ignore
+import kotlin.test.Test
 
 @Ignore
 internal class DocCopySynonyms {

--- a/client/src/commonTest/kotlin/documentation/reference/DocPhilosophy.kt
+++ b/client/src/commonTest/kotlin/documentation/reference/DocPhilosophy.kt
@@ -6,6 +6,7 @@ import com.algolia.search.dsl.attributesToSnippet
 import com.algolia.search.dsl.filters
 import com.algolia.search.dsl.query
 import com.algolia.search.dsl.settings
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.ApplicationID
 import com.algolia.search.model.Attribute
@@ -19,8 +20,6 @@ import com.algolia.search.serialize.internal.Json
 import com.algolia.search.serialize.internal.JsonNonStrict
 import documentation.client
 import documentation.index
-import io.ktor.client.features.ResponseException
-import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -166,10 +165,10 @@ internal class DocPhilosophy {
         runBlocking {
             try {
                 val response = index.search()
-            } catch (exception: ResponseException) {
-                when (exception.response.status) {
-                    HttpStatusCode.NotFound -> TODO()
-                    HttpStatusCode.BadRequest -> TODO()
+            } catch (exception: AlgoliaApiException) {
+                when (exception.httpErrorCode) {
+                    404 -> TODO()
+                    400 -> TODO()
                 }
             }
         }
@@ -180,7 +179,7 @@ internal class DocPhilosophy {
         runBlocking {
             try {
                 val response = index.search()
-            } catch (exception: ResponseException) {
+            } catch (exception: AlgoliaApiException) {
                 TODO()
             } catch (exception: IOException) {
                 TODO()

--- a/client/src/commonTest/kotlin/suite/TestSecuredAPIKeyTools.kt
+++ b/client/src/commonTest/kotlin/suite/TestSecuredAPIKeyTools.kt
@@ -3,6 +3,7 @@ package suite
 import clientAdmin1
 import clientSearch
 import com.algolia.search.client.ClientSearch
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.IndexName
 import com.algolia.search.model.apikey.SecuredAPIKeyRestriction
@@ -11,7 +12,6 @@ import com.algolia.search.model.apikey.getSecuredApiKeyRemainingValidity
 import com.algolia.search.model.internal.Time
 import com.algolia.search.model.task.TaskStatus
 import com.algolia.search.serialize.KeyObjectID
-import io.ktor.client.features.ResponseException
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import runBlocking
@@ -46,7 +46,7 @@ internal class TestSecuredAPIKeyTools {
             }
             client.apply {
                 initIndex(indexName).search()
-                shouldFailWith<ResponseException> { initIndex(indexNameDev).search() }
+                shouldFailWith<AlgoliaApiException> { initIndex(indexNameDev).search() }
             }
         }
     }

--- a/client/src/commonTest/kotlin/suite/TestSuiteABTest.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteABTest.kt
@@ -2,6 +2,7 @@ package suite
 
 import clientAdmin1
 import clientAnalytics
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.model.ClientDate
 import com.algolia.search.model.analytics.ABTest
 import com.algolia.search.model.analytics.ABTestStatus
@@ -10,8 +11,8 @@ import com.algolia.search.model.internal.Time
 import com.algolia.search.model.task.TaskStatus
 import com.algolia.search.serialize.KeyObjectID
 import dayInMillis
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import runBlocking
@@ -19,7 +20,6 @@ import shouldEqual
 import shouldFailWith
 import shouldNotBeNull
 import shouldNotEqual
-import kotlin.test.Test
 
 internal class TestSuiteABTest {
 
@@ -58,11 +58,11 @@ internal class TestSuiteABTest {
                 clientAnalytics.getABTest(responseA.abTestID).status shouldEqual ABTestStatus.Stopped
                 clientAnalytics.deleteABTest(responseA.abTestID).wait() shouldEqual TaskStatus.Published
 
-                val responseB = shouldFailWith<ResponseException> {
+                val responseB = shouldFailWith<AlgoliaApiException> {
                     clientAnalytics.getABTest(responseA.abTestID)
                 }
 
-                responseB.response.status.value shouldEqual HttpStatusCode.NotFound.value
+                responseB.httpErrorCode shouldEqual HttpStatusCode.NotFound.value
             }
         }
     }

--- a/client/src/commonTest/kotlin/suite/TestSuiteABTest.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteABTest.kt
@@ -12,7 +12,6 @@ import com.algolia.search.model.task.TaskStatus
 import com.algolia.search.serialize.KeyObjectID
 import dayInMillis
 import io.ktor.http.HttpStatusCode
-import kotlin.test.Test
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import runBlocking
@@ -20,6 +19,7 @@ import shouldEqual
 import shouldFailWith
 import shouldNotBeNull
 import shouldNotEqual
+import kotlin.test.Test
 
 internal class TestSuiteABTest {
 

--- a/client/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteAPIKey.kt
@@ -1,6 +1,7 @@
 package suite
 
 import clientAdmin1
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toIndexName
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.apikey.ACL
@@ -9,7 +10,6 @@ import com.algolia.search.model.search.Query
 import com.algolia.search.model.search.TypoTolerance
 import com.algolia.search.serialize.internal.toJsonNoDefaults
 import com.algolia.search.serialize.internal.urlEncode
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -61,8 +61,8 @@ internal class TestSuiteAPIKey {
                 while (isActive) {
                     try {
                         if (getAPIKey(key).maxHitsPerQuery == 42) break
-                    } catch (exception: ResponseException) {
-                        exception.response.status.value shouldEqual HttpStatusCode.NotFound
+                    } catch (exception: AlgoliaApiException) {
+                        exception.httpErrorCode shouldEqual HttpStatusCode.NotFound
                     }
                     delay(1000L)
                 }

--- a/client/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
@@ -6,9 +6,7 @@ import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toUserID
 import com.algolia.search.model.multicluster.UserID
 import com.algolia.search.model.multicluster.UserIDQuery
-import io.ktor.client.statement.readBytes
 import io.ktor.http.HttpStatusCode
-import io.ktor.utils.io.core.String
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import runBlocking

--- a/client/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteMultiCluster.kt
@@ -2,10 +2,10 @@ package suite
 
 import DateFormat
 import clientMcm
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toUserID
 import com.algolia.search.model.multicluster.UserID
 import com.algolia.search.model.multicluster.UserIDQuery
-import io.ktor.client.features.ResponseException
 import io.ktor.client.statement.readBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.core.String
@@ -34,8 +34,8 @@ internal class TestSuiteMultiCluster {
             try {
                 clientMcm.getUserID(userID)
                 break
-            } catch (exception: ResponseException) {
-                exception.response.status shouldEqual HttpStatusCode.NotFound
+            } catch (exception: AlgoliaApiException) {
+                exception.httpErrorCode shouldEqual HttpStatusCode.NotFound.value
             }
             delay(1000L)
         }
@@ -45,16 +45,15 @@ internal class TestSuiteMultiCluster {
         loop@ while (coroutineContext.isActive) {
             try {
                 clientMcm.removeUserID(userID)
-            } catch (exception: ResponseException) {
-                val response = exception.response
-                when (response.status) {
-                    HttpStatusCode.NotFound -> break@loop
-                    HttpStatusCode.BadRequest ->
-                        if (String(response.readBytes()).contains("is already migrating")) {
+            } catch (exception: AlgoliaApiException) {
+                when (exception.httpErrorCode) {
+                    HttpStatusCode.NotFound.value -> break@loop
+                    HttpStatusCode.BadRequest.value ->
+                        if (exception.message?.contains("is already migrating") == true) {
                             break@loop
                         } else {
                             // Loop until we don't have Error 400: "Another mapping operation is already running for this userID"
-                            println(String(response.readBytes()))
+                            println(exception.message)
                         }
                 }
             }

--- a/client/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
@@ -1,6 +1,7 @@
 package suite
 
 import clientAdmin1
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toObjectID
 import com.algolia.search.model.rule.Rule
 import com.algolia.search.model.synonym.Synonym
@@ -54,22 +55,22 @@ class TestSuiteReplaceAll {
                 getSynonym(objectIDTwo).objectID shouldEqual objectIDTwo
 
                 (
-                    shouldFailWith<ResponseException> {
+                    shouldFailWith<AlgoliaApiException> {
                         getObject(objectIDOne)
                     }
-                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
+                    ).httpErrorCode shouldEqual HttpStatusCode.NotFound.value
 
                 (
-                    shouldFailWith<ResponseException> {
+                    shouldFailWith<AlgoliaApiException> {
                         getSynonym(objectIDOne)
                     }
-                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
+                    ).httpErrorCode shouldEqual HttpStatusCode.NotFound.value
 
                 (
-                    shouldFailWith<ResponseException> {
+                    shouldFailWith<AlgoliaApiException> {
                         getRule(objectIDOne)
                     }
-                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
+                    ).httpErrorCode shouldEqual HttpStatusCode.NotFound.value
             }
         }
     }

--- a/client/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteReplaceAll.kt
@@ -8,7 +8,6 @@ import com.algolia.search.model.synonym.Synonym
 import com.algolia.search.model.task.Task
 import com.algolia.search.model.task.TaskStatus
 import com.algolia.search.serialize.KeyObjectID
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive

--- a/client/src/commonTest/kotlin/suite/TestSuiteRules.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteRules.kt
@@ -10,13 +10,13 @@ import com.algolia.search.model.settings.Settings
 import com.algolia.search.model.task.Task
 import com.algolia.search.model.task.TaskStatus
 import io.ktor.http.HttpStatusCode
-import kotlin.test.Test
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonObject
 import runBlocking
 import shouldEqual
 import shouldFailWith
 import shouldNotBeNull
+import kotlin.test.Test
 
 internal class TestSuiteRules {
 

--- a/client/src/commonTest/kotlin/suite/TestSuiteRules.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteRules.kt
@@ -1,6 +1,7 @@
 package suite
 
 import clientAdmin1
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toAttribute
 import com.algolia.search.model.rule.Rule
 import com.algolia.search.model.search.Query
@@ -8,15 +9,14 @@ import com.algolia.search.model.settings.AttributeForFaceting
 import com.algolia.search.model.settings.Settings
 import com.algolia.search.model.task.Task
 import com.algolia.search.model.task.TaskStatus
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonObject
 import runBlocking
 import shouldEqual
 import shouldFailWith
 import shouldNotBeNull
-import kotlin.test.Test
 
 internal class TestSuiteRules {
 
@@ -59,10 +59,10 @@ internal class TestSuiteRules {
 
                 search(Query(ruleContexts = listOf("summer"))).nbHits shouldEqual 1
                 (
-                    shouldFailWith<ResponseException> {
+                    shouldFailWith<AlgoliaApiException> {
                         getRule(rule.objectID)
                     }
-                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
+                    ).httpErrorCode shouldEqual HttpStatusCode.NotFound.value
                 clearRules().wait() shouldEqual TaskStatus.Published
                 searchRules().nbHits shouldEqual 0
             }

--- a/client/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
@@ -1,14 +1,15 @@
 package suite
 
 import clientAdmin1
+import com.algolia.search.exception.AlgoliaApiException
 import com.algolia.search.helper.toObjectID
 import com.algolia.search.model.synonym.Synonym
 import com.algolia.search.model.synonym.SynonymQuery
 import com.algolia.search.model.synonym.SynonymType
 import com.algolia.search.model.task.Task
 import com.algolia.search.model.task.TaskStatus
-import io.ktor.client.features.ResponseException
 import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonObject
 import runBlocking
@@ -16,7 +17,6 @@ import shouldBeTrue
 import shouldContain
 import shouldEqual
 import shouldFailWith
-import kotlin.test.Test
 
 internal class TestSuiteSynonyms {
 
@@ -67,10 +67,10 @@ internal class TestSuiteSynonyms {
                 }
                 deleteSynonym(gba).wait() shouldEqual TaskStatus.Published
                 (
-                    shouldFailWith<ResponseException> {
+                    shouldFailWith<AlgoliaApiException> {
                         getSynonym(gba)
                     }
-                    ).response.status.value shouldEqual HttpStatusCode.NotFound.value
+                    ).httpErrorCode shouldEqual HttpStatusCode.NotFound.value
 
                 clearSynonyms().wait() shouldEqual TaskStatus.Published
                 searchSynonyms(SynonymQuery(page = 0, hitsPerPage = 10)).nbHits shouldEqual 0

--- a/client/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteSynonyms.kt
@@ -9,7 +9,6 @@ import com.algolia.search.model.synonym.SynonymType
 import com.algolia.search.model.task.Task
 import com.algolia.search.model.task.TaskStatus
 import io.ktor.http.HttpStatusCode
-import kotlin.test.Test
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonObject
 import runBlocking
@@ -17,6 +16,7 @@ import shouldBeTrue
 import shouldContain
 import shouldEqual
 import shouldFailWith
+import kotlin.test.Test
 
 internal class TestSuiteSynonyms {
 

--- a/docs/ExceptionHandling.md
+++ b/docs/ExceptionHandling.md
@@ -15,10 +15,10 @@ However, an HTTP exception can occur. Handle it with a try / catch block.
 ```kotlin
 try {
     val response = index.search()
-} catch (exception: ResponseException) {
-    when (exception.response.status) {
-        HttpStatusCode.NotFound -> TODO()
-        HttpStatusCode.BadRequest -> TODO()
+} catch (exception: AlgoliaApiException) {
+    when (exception.httpErrorCode) {
+        404 -> TODO()
+        400 -> TODO()
     }
 }
 ```
@@ -30,7 +30,7 @@ Other kinds of exceptions can occur. Handle them appropriately.
 ```kotlin
 try {
     val response = index.search()
-} catch (exception: ResponseException) {
+} catch (exception: AlgoliaApiException) {
     TODO()
 } catch (exception: IOException) {
     TODO()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #312   <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

At transport layer, throws `AlgoliaRuntimeException` instances instead of Ktor's exceptions.
