### PR TITLE
chore: update kotlin to `1.6.21`

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(libs.ktor.client.core)
+                api(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.logging)
                 implementation(libs.ktor.client.serialization.json)
                 implementation(libs.ktor.client.content.negotiation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ktor = "2.0.1"
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common" }
 kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.3.3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.6.1" }
 
 # Ktor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.6.20"
+kotlin = "1.6.21"
 ktor = "2.0.1"
 
 [libraries]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

* Update Kotlin to `1.6.21`
* Expose `kotlinx.serialization.json` as api
