### PR TITLE
chore: add maven bom

### DIFF
--- a/client-bom/build.gradle.kts
+++ b/client-bom/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+    id("java-platform")
+}
+
+dependencies {
+    constraints {
+        api(projects.client)
+        api(libs.ktor.client.android)
+        api(libs.ktor.client.apache)
+        api(libs.ktor.client.cio)
+        api(libs.ktor.client.java)
+        api(libs.ktor.client.jetty)
+        api(libs.ktor.client.okhttp)
+    }
+}
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        from(project.components["javaPlatform"])
+    }
+}

--- a/client-bom/gradle.properties
+++ b/client-bom/gradle.properties
@@ -1,0 +1,2 @@
+POM_NAME=Algolia Search API Client for Kotlin
+POM_ARTIFACT_ID=algoliasearch-client-kotlin-bom

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,15 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref =
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+# Ktor engines
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-client-apache = { group = "io.ktor", name = "ktor-client-apache", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
+ktor-client-jetty = { group = "io.ktor", name = "ktor-client-jetty", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
-ktor-client-apache = { group = "io.ktor", name = "ktor-client-apache", version.ref = "ktor" }
 
 [plugins]
 kotlin-multiplaform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,3 @@
-rootProject.name = "algoliasearch-client-kotlin"
-enableFeaturePreview("VERSION_CATALOGS")
-
-include(":client")
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -17,3 +12,11 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
+
+rootProject.name = "algoliasearch-client-kotlin"
+
+include(":client")
+include(":client-bom")
+
+enableFeaturePreview("VERSION_CATALOGS")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | yes


## Describe your change

Adds the possibility to use [BOM](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import):

```kotlin
dependencies {
    // import Kotlin API client BOM
    implementation(platform("com.algolia:algoliasearch-client-kotlin-bom:2.1.0-SNAPSHOT"))
    
    // define dependencies without versions
    implementation("com.algolia:algoliasearch-client-kotlin")
    implementation("io.ktor:ktor-client-okhttp")
}
```