### PR TITLE
fix: propagate coroutine cancellation

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/transport/internal/Transport.kt
@@ -27,6 +27,7 @@ import io.ktor.http.URLProtocol
 import io.ktor.http.path
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.errors.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -144,6 +145,7 @@ internal class Transport(
      */
     private suspend fun RetryableHost.onError(throwable: Throwable) {
         when (throwable) {
+            is CancellationException -> throw throwable // propagate coroutine cancellation
             is ClientRequestException -> throw throwable.asApiException()
             is HttpRequestTimeoutException, is SocketTimeoutException, is ConnectTimeoutException -> mutex.withLock { hasTimedOut() }
             is IOException, is ResponseException -> mutex.withLock { hasFailed() }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #370
| Need Doc update   | no


## Describe your change

Coroutine's `CancellationException` is propagated when an operation is cancelled.
