### PR TITLE
fix(rules): exclude `renderingContent` from `Consequence`'s `query`

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/Consequence.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/Consequence.kt
@@ -113,6 +113,7 @@ public data class Consequence(
                 if (edits != null) remove(Key.Query)
                 remove(Key.AutomaticFacetFilters)
                 remove(Key.AutomaticOptionalFacetFilters)
+                remove(Key.RenderingContent)
             }
             return if (modified.isNotEmpty()) {
                 JsonNoDefaults.decodeFromJsonElement(Query.serializer(), JsonObject(modified))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #384 


## Describe your change

Exclude `renderingContent` from `Consequence`'s `query`.