### PR TITLE
feat: Add convenience method to use getObjects with a serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## [Unreleased]
+
+### Added
+
+- Convenience `getObjects` method with serializer (#392)
+
 # 2.1.5
 
 ### feat:
 - **Search**: add basic support of extensions (#398)
-
 
 # 2.1.4
 

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointIndexing.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointIndexing.kt
@@ -261,7 +261,19 @@ public interface EndpointIndexing {
         objectIDs: List<ObjectID>,
         attributesToRetrieve: List<Attribute>? = null,
         requestOptions: RequestOptions? = null
-    ): ResponseObjects
+    ): ResponseObjects<JsonObject?>
+
+    /**
+     * Get multiple records using their [ObjectID].
+     *
+     * @see getObject
+     */
+    public suspend fun <T : Indexable> getObjects(
+        serializer: KSerializer<T>,
+        objectIDs: List<ObjectID>,
+        attributesToRetrieve: List<Attribute>? = null,
+        requestOptions: RequestOptions? = null
+    ): ResponseObjects<T?>
 
     /**
      * Update one or more attributes of an existing record.

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointMultipleIndex.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointMultipleIndex.kt
@@ -18,6 +18,7 @@ import com.algolia.search.model.response.ResponseObjects
 import com.algolia.search.model.response.ResponseSearches
 import com.algolia.search.model.search.Query
 import com.algolia.search.transport.RequestOptions
+import kotlinx.serialization.json.JsonObject
 
 public interface EndpointMultipleIndex {
 
@@ -82,7 +83,7 @@ public interface EndpointMultipleIndex {
     public suspend fun multipleGetObjects(
         requests: List<RequestObjects>,
         requestOptions: RequestOptions? = null
-    ): ResponseObjects
+    ): ResponseObjects<JsonObject?>
 
     /**
      * Perform several indexing operations in one API call.

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointMultipleIndex.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/internal/EndpointMultipleIndex.kt
@@ -27,6 +27,7 @@ import com.algolia.search.transport.RequestOptions
 import com.algolia.search.transport.internal.Transport
 import io.ktor.http.HttpMethod
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 
 internal class EndpointMultipleIndexImpl(
@@ -54,7 +55,7 @@ internal class EndpointMultipleIndexImpl(
     override suspend fun multipleGetObjects(
         requests: List<RequestObjects>,
         requestOptions: RequestOptions?,
-    ): ResponseObjects {
+    ): ResponseObjects<JsonObject?> {
         val body = JsonNoDefaults.encodeToString(RequestRequestObjects.serializer(), RequestRequestObjects(requests))
 
         return transport.request(HttpMethod.Post, CallType.Read, "${Route.IndexesV1}/*/objects", requestOptions, body)

--- a/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseObjects.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseObjects.kt
@@ -3,14 +3,13 @@ package com.algolia.search.model.response
 import com.algolia.search.serialize.internal.Key
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 
 @Serializable
-public data class ResponseObjects(
+public data class ResponseObjects<T>(
     /**
      * List of requested records. If a record is not found, it will be marked as null in the list.
      */
-    @SerialName(Key.Results) val results: List<JsonObject?>,
+    @SerialName(Key.Results) val results: List<T?>,
     /**
      * Optional error message in case of failure to retrieve a requested record.
      */

--- a/client/src/commonTest/kotlin/documentation/methods/indexing/DocGetObjects.kt
+++ b/client/src/commonTest/kotlin/documentation/methods/indexing/DocGetObjects.kt
@@ -61,6 +61,7 @@ internal class DocGetObjects {
     fun snippet3() {
         runTest {
             index.getObjects(listOf(ObjectID("myID1"), ObjectID("myID2")))
+            index.getObjects(Contact.serializer(), listOf(ObjectID("myID1"), ObjectID("myID2")))
         }
     }
 
@@ -71,6 +72,7 @@ internal class DocGetObjects {
             val attributes = listOf(Attribute("firstname"), Attribute("lastname"))
 
             index.getObjects(objectIDs, attributes)
+            index.getObjects(Contact.serializer(), objectIDs, attributes)
         }
     }
 
@@ -82,6 +84,7 @@ internal class DocGetObjects {
             }
 
             index.getObjects(listOf(ObjectID("myID1"), ObjectID("myID2")), requestOptions = requestOptions)
+            index.getObjects(Contact.serializer(), listOf(ObjectID("myID1"), ObjectID("myID2")), requestOptions = requestOptions)
         }
     }
 }

--- a/client/src/commonTest/kotlin/suite/TestSuiteIndexing.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteIndexing.kt
@@ -76,6 +76,8 @@ internal class TestSuiteIndexing {
                 getObjects(objectIDs).results
                     .filterNotNull()
                     .map { Json.decodeFromJsonElement(Data.serializer(), it) } shouldEqual batches
+                getObjects(Data.serializer(), objectIDs).results
+                    .filterNotNull() shouldEqual batches
                 browse().nbHits shouldEqual 1007
                 revisions += replaceObject(Data.serializer(), updateA)
                 revisions += partialUpdateObject(dataE.objectID, Partial.Increment(attributeValue, 1))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #...
| Need Doc update   | yes


## Describe your change

Add a convenience method `getObjects` having a serializer as parameter to easily serialize objects after retrieval
