### PR TITLE
fix(filters): issue with textual value escaping

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/filter/internal/Filter.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/filter/internal/Filter.kt
@@ -4,7 +4,8 @@ import com.algolia.search.model.Attribute
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.NumericOperator
 
-internal fun String.escape() = "\"$this\""
+internal fun String.escape() = "\"${this.escapeQuotation()}\""
+internal fun String.escapeQuotation() = this.replace("\"", "\\\"")
 
 internal fun Attribute.escape() = raw.escape()
 
@@ -93,7 +94,7 @@ internal fun Filter.Numeric.toLegacy(escape: Boolean): List<String> {
 
 internal fun Filter.Facet.Value.toLegacy(isNegated: Boolean, escape: Boolean): String {
     val value = when (this) {
-        is Filter.Facet.Value.String -> if (escape) raw.escape() else raw
+        is Filter.Facet.Value.String -> if (escape) raw.escape() else raw.escapeQuotation()
         is Filter.Facet.Value.Number -> raw.toString()
         is Filter.Facet.Value.Boolean -> raw.toString()
     }
@@ -109,7 +110,7 @@ internal fun Filter.Facet.toLegacy(escape: Boolean): List<String> {
 }
 
 internal fun Filter.Tag.toLegacy(escape: Boolean): List<String> {
-    val raw = if (escape) value.escape() else value
+    val raw = if (escape) value.escape() else value.escapeQuotation()
     val value = if (isNegated) "-$raw" else raw
 
     return listOf(value)

--- a/client/src/commonTest/kotlin/model/filter/TestFilterFacetString.kt
+++ b/client/src/commonTest/kotlin/model/filter/TestFilterFacetString.kt
@@ -12,6 +12,7 @@ internal class TestFilterFacetString {
     private val filterNegate = !Filter.Facet(attributeA, "valueA")
     private val filterSpace = Filter.Facet(attributeA, "value with space")
     private val filterScore = Filter.Facet(attributeA, "valueA", 1)
+    private val filterQuotation = Filter.Facet(attributeA, "45\"-50\" tv\'s")
 
     @Test
     fun sql() {
@@ -19,6 +20,7 @@ internal class TestFilterFacetString {
         FilterConverter.SQL(filterNegate) shouldEqual "NOT \"attributeA\":\"valueA\""
         FilterConverter.SQL(filterSpace) shouldEqual "\"attributeA\":\"value with space\""
         FilterConverter.SQL(filterScore) shouldEqual "\"attributeA\":\"valueA\"<score=1>"
+        FilterConverter.SQL(filterQuotation) shouldEqual "\"attributeA\":\"45\\\"-50\\\" tv's\""
     }
 
     @Test
@@ -27,6 +29,7 @@ internal class TestFilterFacetString {
         FilterConverter.Legacy(filterNegate) shouldEqual listOf("\"attributeA\":-\"valueA\"")
         FilterConverter.Legacy(filterSpace) shouldEqual listOf("\"attributeA\":\"value with space\"")
         FilterConverter.Legacy(filterScore) shouldEqual listOf("\"attributeA\":\"valueA\"<score=1>")
+        FilterConverter.Legacy(filterQuotation) shouldEqual listOf("\"attributeA\":\"45\\\"-50\\\" tv's\"")
     }
 
     @Test
@@ -35,5 +38,6 @@ internal class TestFilterFacetString {
         FilterConverter.Legacy.Unquoted(filterNegate) shouldEqual listOf("attributeA:-valueA")
         FilterConverter.Legacy.Unquoted(filterSpace) shouldEqual listOf("attributeA:value with space")
         FilterConverter.Legacy.Unquoted(filterScore) shouldEqual listOf("attributeA:valueA<score=1>")
+        FilterConverter.Legacy.Unquoted(filterQuotation) shouldEqual listOf("attributeA:45\\\"-50\\\" tv's")
     }
 }

--- a/client/src/commonTest/kotlin/model/filter/TestFilterTag.kt
+++ b/client/src/commonTest/kotlin/model/filter/TestFilterTag.kt
@@ -8,22 +8,27 @@ import kotlin.test.Test
 internal class TestFilterTag {
 
     private val filter = Filter.Tag("valueA")
+    private val filterQuotation = Filter.Tag("45\"-50\" tv\'s")
 
     @Test
     fun sql() {
         FilterConverter.SQL(filter) shouldEqual "_tags:\"valueA\""
         FilterConverter.SQL(!filter) shouldEqual "NOT _tags:\"valueA\""
+        FilterConverter.SQL(filterQuotation) shouldEqual "_tags:\"45\\\"-50\\\" tv\'s\""
     }
 
     @Test
     fun legacy() {
         FilterConverter.Legacy(filter) shouldEqual listOf("\"valueA\"")
         FilterConverter.Legacy(!filter) shouldEqual listOf("-\"valueA\"")
+        FilterConverter.Legacy(!filter) shouldEqual listOf("-\"valueA\"")
+        FilterConverter.Legacy(filterQuotation) shouldEqual listOf("\"45\\\"-50\\\" tv\'s\"")
     }
 
     @Test
     fun legacyUnquoted() {
         FilterConverter.Legacy.Unquoted(filter) shouldEqual listOf("valueA")
         FilterConverter.Legacy.Unquoted(!filter) shouldEqual listOf("-valueA")
+        FilterConverter.Legacy.Unquoted(filterQuotation) shouldEqual listOf("45\\\"-50\\\" tv\'s")
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | [CR-3573](https://algolia.atlassian.net/browse/CR-3573)
| Need Doc update   | no


## Describe your change

Adds explicit escaping for the quotation marks in the textual filters values causing a bad search request.
Duplicates the fix [#293](https://github.com/algolia/instantsearch-ios/pull/293) for InstantSearch iOS.

## What problem is this fixing?

### Example
The input `45\"-50\" tv\'s` is transformed to `"45"-50" tv's"` and breaks the JSON format. 

[CR-3573]: https://algolia.atlassian.net/browse/CR-3573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ