### PR TITLE
feat(search): add basic support of `extensions`

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/dsl/DSLQuery.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/dsl/DSLQuery.kt
@@ -17,6 +17,8 @@ import com.algolia.search.dsl.strategy.DSLAdvancedSyntaxFeatures
 import com.algolia.search.dsl.strategy.DSLAlternativesAsExact
 import com.algolia.search.model.filter.FilterGroupsConverter
 import com.algolia.search.model.search.Query
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Create a [Query] with [block] and an optional [query].
@@ -196,4 +198,13 @@ public fun Query.explainModules(block: DSLExplainModules.() -> Unit) {
  */
 public fun Query.naturalLanguages(block: DSLLanguage.() -> Unit) {
     naturalLanguages = DSLLanguage(block)
+}
+
+/**
+ * Assign the output of [block] to [Query.extensions].
+ */
+public fun Query.extensions(block: JsonObjectBuilder.() -> Unit) {
+    extensions = buildJsonObject {
+        block()
+    }
 }

--- a/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseSearch.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseSearch.kt
@@ -10,37 +10,16 @@ import com.algolia.search.model.analytics.ABTestID
 import com.algolia.search.model.filter.FilterGroup
 import com.algolia.search.model.insights.InsightsEvent
 import com.algolia.search.model.rule.RenderingContent
-import com.algolia.search.model.search.Cursor
-import com.algolia.search.model.search.Explain
-import com.algolia.search.model.search.Facet
-import com.algolia.search.model.search.FacetStats
-import com.algolia.search.model.search.Point
-import com.algolia.search.model.search.Query
-import com.algolia.search.model.search.RankingInfo
-import com.algolia.search.model.search.RemoveWordIfNoResults
+import com.algolia.search.model.search.*
 import com.algolia.search.model.settings.Settings
 import com.algolia.search.serialize.KSerializerFacetMap
 import com.algolia.search.serialize.KSerializerPoint
+import com.algolia.search.serialize.internal.*
 import com.algolia.search.serialize.internal.Json
-import com.algolia.search.serialize.internal.JsonNonStrict
-import com.algolia.search.serialize.internal.Key
-import com.algolia.search.serialize.internal.asJsonInput
-import com.algolia.search.serialize.internal.asJsonOutput
-import com.algolia.search.serialize.internal.jsonObjectOrNull
-import com.algolia.search.serialize.internal.jsonPrimitiveOrNull
-import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
+import kotlinx.serialization.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.floatOrNull
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.*
 
 @Serializable
 public data class ResponseSearch(
@@ -213,7 +192,12 @@ public data class ResponseSearch(
      * In case of A/B test, reports the ID of the A/B test used.
      * Returned only if [Query.getRankingInfo] is set to true.
      */
-    @SerialName(Key.ABTestID) val abTestIDOrNull: ABTestID? = null
+    @SerialName(Key.ABTestID) val abTestIDOrNull: ABTestID? = null,
+
+    /**
+     * Search extensions.
+     */
+    @SerialName(Key.Extensions) val extensionsOrNull: JsonObject? = null,
 ) : ResultSearch {
 
     /**
@@ -522,6 +506,12 @@ public data class ResponseSearch(
      */
     public val abTestID: ABTestID
         get() = checkNotNull(abTestIDOrNull)
+
+    /**
+     * Search extensions.
+     */
+    public val extensions: JsonObject
+        get() = requireNotNull(extensionsOrNull)
 
     /**
      * Returns the position (0-based) within the [hits] result list of the record matching against the given [objectID].

--- a/client/src/commonMain/kotlin/com/algolia/search/model/search/Query.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/search/Query.kt
@@ -11,6 +11,7 @@ import com.algolia.search.serialize.KSerializerPoint
 import com.algolia.search.serialize.internal.Key
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 @DSLParameters
@@ -507,4 +508,9 @@ public data class Query(
      * Re-Ranking (with false) at search time.
      */
     @SerialName(Key.EnableReRanking) override var enableReRanking: Boolean? = null,
+
+    /**
+     * Search extensions..
+     */
+    @SerialName(Key.Extensions) public var extensions: JsonObject? = null,
 ) : SearchParameters

--- a/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Key.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Key.kt
@@ -434,4 +434,5 @@ internal object Key {
     const val FallbackParameters: String = "fallbackParameters"
     const val Default: String = "default"
     const val AlgoliaAgent = "X-Algolia-Agent"
+    const val Extensions = "extensions"
 }

--- a/client/src/commonTest/kotlin/Extensions.kt
+++ b/client/src/commonTest/kotlin/Extensions.kt
@@ -2,13 +2,11 @@ import com.algolia.search.model.Attribute
 import com.algolia.search.model.IndexName
 import com.algolia.search.model.ObjectID
 import com.algolia.search.model.filter.Filter
-import com.algolia.search.model.rule.FacetOrdering
-import com.algolia.search.model.rule.FacetValuesOrder
-import com.algolia.search.model.rule.FacetsOrder
-import com.algolia.search.model.rule.RenderingContent
-import com.algolia.search.model.rule.SortRule
+import com.algolia.search.model.rule.*
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 internal fun set(vararg filters: Filter) = mutableSetOf(*filters)
 
@@ -24,6 +22,15 @@ internal val objectIDA = ObjectID("442854")
 internal val objectIDB = ObjectID("322601")
 internal val nestedLists = listOf(listOf(string), listOf(string))
 internal val attributes = listOf(attributeA, attributeB)
+internal val extensions = buildJsonObject {
+    put(
+        key = "queryCategorization",
+        element = buildJsonObject {
+            put("enableCategoriesRetrieval", true)
+            put("enableAutoFiltering", false)
+        },
+    )
+}
 internal val renderingContent = RenderingContent(
     facetOrdering = FacetOrdering(
         facets = FacetsOrder(

--- a/client/src/commonTest/kotlin/dsl/TestDSLQuery.kt
+++ b/client/src/commonTest/kotlin/dsl/TestDSLQuery.kt
@@ -1,32 +1,12 @@
 package dsl
 
 import attributeA
-import com.algolia.search.dsl.alternativesAsExact
-import com.algolia.search.dsl.analyticsTags
-import com.algolia.search.dsl.attributesToHighlight
-import com.algolia.search.dsl.attributesToRetrieve
-import com.algolia.search.dsl.attributesToSnippet
-import com.algolia.search.dsl.disableExactOnAttributes
-import com.algolia.search.dsl.disableTypoToleranceOnAttributes
-import com.algolia.search.dsl.explainModules
-import com.algolia.search.dsl.facetFilters
-import com.algolia.search.dsl.facets
-import com.algolia.search.dsl.filters
-import com.algolia.search.dsl.insideBoundingBox
-import com.algolia.search.dsl.insidePolygon
-import com.algolia.search.dsl.naturalLanguages
-import com.algolia.search.dsl.numericFilters
-import com.algolia.search.dsl.optionalFilters
-import com.algolia.search.dsl.optionalWords
-import com.algolia.search.dsl.query
-import com.algolia.search.dsl.queryLanguages
-import com.algolia.search.dsl.responseFields
-import com.algolia.search.dsl.restrictSearchableAttributes
-import com.algolia.search.dsl.ruleContexts
-import com.algolia.search.dsl.tagFilters
+import com.algolia.search.dsl.*
 import com.algolia.search.helper.and
 import com.algolia.search.model.search.BoundingBox
 import com.algolia.search.model.search.Polygon
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import shouldNotBeNull
 import unknown
 import kotlin.test.Test
@@ -299,5 +279,22 @@ internal class TestDSLQuery {
         }
 
         query.naturalLanguages.shouldNotBeNull()
+    }
+
+    @Test
+    fun extensions() {
+        val query = query {
+            extensions {
+                put(
+                    key = "queryCategorization",
+                    element = buildJsonObject {
+                        put("enableCategoriesRetrieval", true)
+                        put("enableAutoFiltering", false)
+                    },
+                )
+            }
+        }
+
+        query.extensions.shouldNotBeNull()
     }
 }

--- a/client/src/commonTest/kotlin/serialize/search/TestQuery.kt
+++ b/client/src/commonTest/kotlin/serialize/search/TestQuery.kt
@@ -5,24 +5,12 @@ import attributesJson
 import boolean
 import com.algolia.search.helper.and
 import com.algolia.search.model.insights.UserToken
-import com.algolia.search.model.search.AlternativesAsExact
-import com.algolia.search.model.search.AroundPrecision
-import com.algolia.search.model.search.AroundRadius
-import com.algolia.search.model.search.ExactOnSingleWordQuery
-import com.algolia.search.model.search.ExplainModule
-import com.algolia.search.model.search.IgnorePlurals
-import com.algolia.search.model.search.Language
-import com.algolia.search.model.search.Query
-import com.algolia.search.model.search.QueryType
-import com.algolia.search.model.search.RemoveStopWords
-import com.algolia.search.model.search.RemoveWordIfNoResults
-import com.algolia.search.model.search.ResponseFields
-import com.algolia.search.model.search.SortFacetsBy
-import com.algolia.search.model.search.TypoTolerance
+import com.algolia.search.model.search.*
 import com.algolia.search.model.settings.AdvancedSyntaxFeatures
 import com.algolia.search.model.settings.Distinct
 import com.algolia.search.serialize.internal.JsonNoDefaults
 import com.algolia.search.serialize.internal.Key
+import extensions
 import int
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
@@ -109,6 +97,7 @@ internal class TestQuery : TestSerializer<Query>(Query.serializer()) {
             relevancyStrictness = int,
             decompoundQuery = boolean,
             enableReRanking = boolean,
+            extensions = extensions,
         ) to buildJsonObject {
             put(Key.Query, string)
             put(Key.AttributesToRetrieve, attributesJson)
@@ -201,6 +190,7 @@ internal class TestQuery : TestSerializer<Query>(Query.serializer()) {
             put(Key.RelevancyStrictness, int)
             put(Key.DecompoundQuery, boolean)
             put(Key.EnableReRanking, boolean)
+            put(Key.Extensions, extensions)
         }
     )
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes   <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | yes


## Describe your change

Add basic support of `extensions` in both `Query` and `ResponseSearch` as `JsonObject`.