### PR TITLE
feat: replace all objects with loaded objects from a Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+# Unreleased
+
+### feat:
+- **Search**: support `Sequence` as argument of `replaceAllObjects()` (#400)
+
 # 2.1.5
 
 ### feat:
 - **Search**: add basic support of extensions (#398)
-
 
 # 2.1.4
 

--- a/client/api/client.api
+++ b/client/api/client.api
@@ -1691,7 +1691,9 @@ public abstract interface class com/algolia/search/endpoint/EndpointIndexing {
 	public abstract fun partialUpdateObject (Lcom/algolia/search/model/ObjectID;Lcom/algolia/search/model/indexing/Partial;Ljava/lang/Boolean;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun partialUpdateObjects (Ljava/util/List;ZLcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replaceAllObjects (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllObjects (Lkotlin/sequences/Sequence;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replaceAllObjects (Lkotlinx/serialization/KSerializer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replaceAllObjects (Lkotlinx/serialization/KSerializer;Lkotlin/sequences/Sequence;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replaceObject (Lcom/algolia/search/model/ObjectID;Lkotlinx/serialization/json/JsonObject;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replaceObject (Lkotlinx/serialization/KSerializer;Lcom/algolia/search/model/indexing/Indexable;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replaceObjects (Ljava/util/List;Lcom/algolia/search/transport/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointIndexing.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/endpoint/EndpointIndexing.kt
@@ -180,6 +180,26 @@ public interface EndpointIndexing {
     ): List<TaskIndex>
 
     /**
+     * Push a new set of schemaless objects and remove all previous ones.
+     *
+     * @param serializer [KSerializer] of type [T] for serialization.
+     * @param records The sequence of records to replace.
+     */
+    public suspend fun <T> replaceAllObjects(
+        serializer: KSerializer<T>,
+        records: Sequence<T>
+    ): List<TaskIndex>
+
+    /**
+     * Push a new set of schemaless objects and remove all previous ones.
+     *
+     * @see replaceAllObjects
+     */
+    public suspend fun replaceAllObjects(
+        records: Sequence<JsonObject>
+    ): List<TaskIndex>
+
+    /**
      * Remove an object from an index using its [ObjectID].
      *
      * @param objectID The [ObjectID] to identify the record.

--- a/client/src/commonTest/kotlin/suite/TestSuiteIndexing.kt
+++ b/client/src/commonTest/kotlin/suite/TestSuiteIndexing.kt
@@ -115,4 +115,32 @@ internal class TestSuiteIndexing {
             }
         }
     }
+
+    @Test
+    fun testReplaceAll() {
+        runTest {
+            index.apply {
+                val json = listOf(
+                    buildJsonObject {
+                        put("firstname", "Jimmie")
+                        put("lastname", "Barninger")
+                    },
+                    buildJsonObject {
+                        put("firstname", "Warren")
+                        put("lastname", "Speach")
+                    }
+                )
+
+                replaceAllObjects(json).wait()
+                browse().nbHits shouldEqual 2
+
+                val data = generateSequence(1, Int::inc).map {
+                    Data("data_$it".toObjectID())
+                }
+
+                replaceAllObjects(Data.serializer(), data.take(15_000)).wait()
+                browse().nbHits shouldEqual 15_000
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hello, thanks for keeping this client maintained and open! 🙌 
I'm using this client to search and maintain data, and here is a PR that suggests providing more support to lazy programmers:

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | nothing
| Need Doc update   | no


## Describe your change

Support not only the `List` interface but also the `Sequence` interface when replacing all objects in an index.

## What problem is this fixing?

Currently the `replaceAllObjects()` supports the `List` interface only, which means that callers need to load all data onto the Java heap even though it could be huge.

By supporting the `Sequence` interface, callers can generate data lazily and reduce the memory footprint of their code.
