### PR TITLE
fix(rule): add optional filters property to the rule consequence params

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/Consequence.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/Consequence.kt
@@ -40,8 +40,8 @@ public data class Consequence(
      * Filters to promote or demote records in the search results.
      *
      * Implementations:
-     * - [List<OptionalFilters>] - *[OptionalFilters.of]*
-     * - [String] - *[OptionalFilters.of]*
+     * - [List<OptionalFilters>] - *[OptionalFilters()]*
+     * - [String] - *[OptionalFilters()]*
      */
     val optionalFilters: List<OptionalFilters>? = null,
     /**

--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/OptionalFilters.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/OptionalFilters.kt
@@ -17,8 +17,8 @@ import kotlinx.serialization.json.JsonElement
  * - Optional filters don't work with numeric attributes.
  *
  * Implementations:
- * - [List<OptionalFilters>] - *[OptionalFilters.of]*
- * - [String] - *[OptionalFilters.of]*
+ * - [List<OptionalFilters>] - *[OptionalFilters()]*
+ * - [String] - *[OptionalFilters()]*
  */
 @Serializable(OptionalFiltersSerializer::class)
 public sealed interface OptionalFilters {
@@ -32,10 +32,10 @@ public sealed interface OptionalFilters {
 
     public companion object {
 
-        public fun of(value: List<OptionalFilters>): OptionalFilters {
+        public operator fun invoke(value: List<OptionalFilters>): OptionalFilters {
             return ListOfOptionalFiltersValue(value)
         }
-        public fun of(value: String): OptionalFilters {
+        public operator fun invoke(value: String): OptionalFilters {
             return StringValue(value)
         }
     }

--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/OptionalFilters.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/OptionalFilters.kt
@@ -1,0 +1,52 @@
+package com.algolia.search.model.rule
+
+import com.algolia.search.exception.AlgoliaClientException
+import com.algolia.search.serialize.internal.isJsonArray
+import com.algolia.search.serialize.internal.isString
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Filters to promote or demote records in the search results.
+ * Optional filters work like facet filters, but they don't exclude records from the search results.
+ * Records that match the optional filter rank before records that don't match. If you're using a negative filter `facet:-value`, matching records rank after records that don't match.
+ * - Optional filters don't work on virtual replicas.
+ * - Optional filters are applied _after_ `sort-by` attributes.
+ * - Optional filters don't work with numeric attributes.
+ *
+ * Implementations:
+ * - [List<OptionalFilters>] - *[OptionalFilters.of]*
+ * - [String] - *[OptionalFilters.of]*
+ */
+@Serializable(OptionalFiltersSerializer::class)
+public sealed interface OptionalFilters {
+    @Serializable
+    @JvmInline
+    public value class ListOfOptionalFiltersValue(public val value: List<OptionalFilters>) : OptionalFilters
+
+    @Serializable
+    @JvmInline
+    public value class StringValue(public val value: String) : OptionalFilters
+
+    public companion object {
+
+        public fun of(value: List<OptionalFilters>): OptionalFilters {
+            return ListOfOptionalFiltersValue(value)
+        }
+        public fun of(value: String): OptionalFilters {
+            return StringValue(value)
+        }
+    }
+}
+
+internal class OptionalFiltersSerializer : JsonContentPolymorphicSerializer<OptionalFilters>(OptionalFilters::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<OptionalFilters> {
+        return when {
+            element.isJsonArray -> OptionalFilters.ListOfOptionalFiltersValue.serializer()
+            element.isString -> OptionalFilters.StringValue.serializer()
+            else -> throw AlgoliaClientException("Failed to deserialize json element: $element")
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Json.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Json.kt
@@ -119,3 +119,15 @@ internal val JsonElement.jsonArrayOrNull: JsonArray?
  */
 internal val JsonElement.jsonPrimitiveOrNull: JsonPrimitive?
     get() = this as? JsonPrimitive
+
+/**
+ * Returns true if [JsonElement] is a string, false otherwise.
+ */
+internal val JsonElement.isString: Boolean
+    get() = this is JsonPrimitive && isString
+
+/**
+ * Returns true if [JsonElement] is a [JsonArray], false otherwise.
+ */
+internal val JsonElement.isJsonArray: Boolean
+    get() = this is JsonArray

--- a/client/src/commonTest/kotlin/serialize/rule/TestConsequence.kt
+++ b/client/src/commonTest/kotlin/serialize/rule/TestConsequence.kt
@@ -33,9 +33,9 @@ internal class TestConsequence : TestSerializer<Consequence>(Consequence.seriali
     private val filtersJson = Json.encodeToJsonElement(ListSerializer(AutomaticFacetFilters.serializer()), filters)
     // {"optionalFilters":[["foo","bar"],"b",["alice","bob"]]}
     private val optionalFilters = listOf(
-        OptionalFilters.of(listOf(OptionalFilters.of("foo"), OptionalFilters.of("bar"))),
-        OptionalFilters.of("b"),
-        OptionalFilters.of(listOf(OptionalFilters.of("alice"), OptionalFilters.of("bob")))
+        OptionalFilters(listOf(OptionalFilters("foo"), OptionalFilters("bar"))),
+        OptionalFilters("b"),
+        OptionalFilters(listOf(OptionalFilters("alice"), OptionalFilters("bob")))
     )
 
     override val items = listOf(

--- a/client/src/commonTest/kotlin/serialize/rule/TestConsequence.kt
+++ b/client/src/commonTest/kotlin/serialize/rule/TestConsequence.kt
@@ -2,14 +2,7 @@ package serialize.rule
 
 import attributeA
 import com.algolia.search.helper.toObjectID
-import com.algolia.search.model.rule.Anchoring
-import com.algolia.search.model.rule.AutomaticFacetFilters
-import com.algolia.search.model.rule.Condition
-import com.algolia.search.model.rule.Consequence
-import com.algolia.search.model.rule.Edit
-import com.algolia.search.model.rule.Pattern
-import com.algolia.search.model.rule.Promotion
-import com.algolia.search.model.rule.Rule
+import com.algolia.search.model.rule.*
 import com.algolia.search.model.search.Query
 import com.algolia.search.serialize.internal.Json
 import com.algolia.search.serialize.internal.JsonNoDefaults
@@ -38,6 +31,12 @@ internal class TestConsequence : TestSerializer<Consequence>(Consequence.seriali
     private val promotionsSerialized = Json.encodeToJsonElement(ListSerializer(Promotion.serializer()), promotions)
     private val userData = buildJsonObject { put(Key.UserData, unknown) }
     private val filtersJson = Json.encodeToJsonElement(ListSerializer(AutomaticFacetFilters.serializer()), filters)
+    // {"optionalFilters":[["foo","bar"],"b",["alice","bob"]]}
+    private val optionalFilters = listOf(
+        OptionalFilters.of(listOf(OptionalFilters.of("foo"), OptionalFilters.of("bar"))),
+        OptionalFilters.of("b"),
+        OptionalFilters.of(listOf(OptionalFilters.of("alice"), OptionalFilters.of("bob")))
+    )
 
     override val items = listOf(
         Consequence() to buildJsonObject { },
@@ -85,6 +84,18 @@ internal class TestConsequence : TestSerializer<Consequence>(Consequence.seriali
                     put(Key.Query, unknown)
                     put(Key.AutomaticFacetFilters, filtersJson)
                     put(Key.AutomaticOptionalFacetFilters, filtersJson)
+                }
+            )
+        },
+        Consequence(optionalFilters = optionalFilters, query = query) to buildJsonObject {
+            put(
+                Key.Params,
+                buildJsonObject {
+                    put(Key.Query, unknown)
+                    put(
+                        Key.OptionalFilters,
+                        Json.encodeToJsonElement(ListSerializer(OptionalFilters.serializer()), optionalFilters)
+                    )
                 }
             )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "2.2.3"
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common" }
 kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.4.1" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.6.3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.6.4" }
 
 # Ktor


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix [DI-1984] [CR-6113]
| Need Doc update   | yes


## Describe your change
Add a new `OptionalFilters` interface with a polymorphic serializer so they can be either a list of OptionalFilters or a String
Add a new optionalFilters property in the rule `Consequence` class that is a `List<OptionalFilters>`

## What problem is this fixing?
Rule consequence param `optionalFilters` weren't deserialized and could cause a crash if they were present in the request response

[DI-1984]: https://algolia.atlassian.net/browse/DI-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CR-6113]: https://algolia.atlassian.net/browse/CR-6113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ