### PR TITLE
fix(event): add object data prop to the insights conversion event

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/insights/InsightsEvent.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/insights/InsightsEvent.kt
@@ -1,11 +1,13 @@
 package com.algolia.search.model.insights
 
+import ObjectData
 import com.algolia.search.endpoint.EndpointInsights
 import com.algolia.search.model.IndexName
 import com.algolia.search.model.ObjectID
 import com.algolia.search.model.QueryID
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.FilterConverter
+import com.algolia.search.serialize.internal.JsonNoDefaults
 import com.algolia.search.serialize.internal.Key
 import com.algolia.search.serialize.internal.asJsonOutput
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -39,7 +41,7 @@ public sealed class InsightsEvent {
         override val userToken: UserToken? = null,
         override val timestamp: Long? = null,
         override val queryID: QueryID? = null,
-        override val resources: Resources? = null
+        override val resources: Resources? = null,
     ) : InsightsEvent()
 
     public data class Click(
@@ -49,7 +51,7 @@ public sealed class InsightsEvent {
         override val timestamp: Long? = null,
         override val queryID: QueryID? = null,
         override val resources: Resources? = null,
-        val positions: List<Int>? = null
+        val positions: List<Int>? = null,
     ) : InsightsEvent() {
 
         init {
@@ -64,7 +66,8 @@ public sealed class InsightsEvent {
         override val userToken: UserToken? = null,
         override val timestamp: Long? = null,
         override val queryID: QueryID? = null,
-        override val resources: Resources? = null
+        override val resources: Resources? = null,
+        val objectData: List<ObjectData>? = null
     ) : InsightsEvent()
 
     public sealed class Resources {
@@ -134,6 +137,17 @@ public sealed class InsightsEvent {
                             Key.Positions,
                             buildJsonArray { it.forEach { add((it as Number)) } }
                         )
+                    }
+                }
+                if (value is Conversion) {
+                    value.objectData?.let {
+                        put(
+                            Key.ObjectData,
+                            buildJsonArray {
+                                it.forEach { add(JsonNoDefaults.encodeToJsonElement(ObjectData.serializer(), it)) }
+                            }
+                        )
+
                     }
                 }
             }

--- a/client/src/commonMain/kotlin/com/algolia/search/model/insights/ObjectData.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/insights/ObjectData.kt
@@ -1,0 +1,57 @@
+import com.algolia.search.serialize.internal.Key
+import com.algolia.search.serialize.internal.asJsonInput
+import com.algolia.search.serialize.internal.asJsonOutput
+import com.algolia.search.serialize.internal.jsonPrimitiveOrNull
+import kotlinx.serialization.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+
+/**
+ * ObjectData
+ *
+ * @param queryID Unique identifier for a search query, used to track purchase events with multiple records that originate from different searches.
+ * @param price
+ * @param quantity Quantity of a product that has been purchased or added to the cart. The total purchase value is the sum of `quantity` multiplied with the `price` for each purchased item.
+ * @param discount
+ */
+@Serializable(ObjectData.Companion::class)
+public data class ObjectData(
+
+    /** Unique identifier for a search query, used to track purchase events with multiple records that originate from different searches. */
+    @SerialName(value = Key.QueryID) val queryID: String? = null,
+
+    @SerialName(value = Key.Price) val price: String? = null,
+
+    /** Quantity of a product that has been purchased or added to the cart. The total purchase value is the sum of `quantity` multiplied with the `price` for each purchased item.  */
+    @SerialName(value = Key.Quantity) val quantity: Int? = null,
+
+    @SerialName(value = Key.Discount) val discount: String? = null,
+
+
+) {
+    @Serializer(ObjectData::class)
+    @OptIn(ExperimentalSerializationApi::class)
+    public companion object : KSerializer<ObjectData> {
+
+        override fun serialize(encoder: Encoder, value: ObjectData) {
+            val json = buildJsonObject {
+                value.queryID?.let { put(Key.QueryID, it) }
+                value.price?.let { put(Key.Price, it) }
+                value.quantity?.let { put(Key.Quantity, it) }
+                value.discount?.let { put(Key.Discount, it) }
+            }
+            encoder.asJsonOutput().encodeJsonElement(json)
+        }
+
+        override fun deserialize(decoder: Decoder): ObjectData {
+            val json = decoder.asJsonInput().jsonObject
+            return ObjectData(
+                queryID = json.getValue(Key.QueryID).jsonPrimitiveOrNull?.contentOrNull,
+                price = json.getValue(Key.Price).jsonPrimitiveOrNull?.contentOrNull,
+                quantity = json.getValue(Key.Quantity).jsonPrimitiveOrNull?.intOrNull,
+                discount = json.getValue(Key.Discount).jsonPrimitiveOrNull?.contentOrNull,
+            )
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Key.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/serialize/internal/Key.kt
@@ -440,4 +440,8 @@ internal object Key {
     const val AlgoliaAgent = "X-Algolia-Agent"
     const val Extensions = "extensions"
     const val DeletedUntil = "deletedUntil"
+    const val ObjectData: String = "objectData"
+    const val Price: String = "price"
+    const val Quantity: String = "quantity"
+    const val Discount: String = "discount"
 }

--- a/client/src/commonTest/kotlin/model/insights/TestInsightsEvent.kt
+++ b/client/src/commonTest/kotlin/model/insights/TestInsightsEvent.kt
@@ -1,20 +1,35 @@
 package model.insights
 
+import ObjectData
 import attributeA
 import com.algolia.search.helper.toEventName
 import com.algolia.search.helper.toQueryID
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.insights.InsightsEvent
+import com.algolia.search.serialize.internal.JsonNoDefaults
+import com.algolia.search.serialize.internal.Key
 import indexA
 import objectIDA
 import shouldEqual
 import shouldFailWith
 import kotlin.test.Test
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 
 internal class TestInsightsEvent {
 
     private val eventName = "eventName".toEventName()
     private val filter = Filter.Facet(attributeA, "value")
+    private val conversionEventWithObjectData = InsightsEvent.Conversion(
+        eventName = eventName,
+        indexName = indexA,
+        objectData = listOf(
+            ObjectData(price = "10", queryID = "queryID", quantity = 1),
+            ObjectData(price = "20", queryID = "queryID2", quantity = 2)
+        )
+    )
 
     @Test
     fun positionsAreRequired() {
@@ -47,5 +62,31 @@ internal class TestInsightsEvent {
         InsightsEvent.Resources.Filters(underTheSizeLimit).filters shouldEqual underTheSizeLimit
         InsightsEvent.Resources.Filters(equalToTheSizeLimit).filters shouldEqual equalToTheSizeLimit
         shouldFailWith<IllegalArgumentException> { InsightsEvent.Resources.Filters(overTheSizeLimit) }
+    }
+
+    @Test
+    fun objectDataSerializer() {
+        JsonNoDefaults.encodeToJsonElement(InsightsEvent.serializer(), conversionEventWithObjectData).jsonObject shouldEqual
+            buildJsonObject {
+                put(Key.EventType, Key.Conversion)
+                put(Key.EventName, eventName.raw)
+                put(Key.Index, indexA.raw)
+                put(Key.ObjectData, buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("price", "10")
+                            put("queryID", "queryID")
+                            put("quantity", 1)
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("price", "20")
+                            put("queryID", "queryID2")
+                            put("quantity", 2)
+                        }
+                    )
+                })
+            }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix [CR-6083] [DI-2022]
| Need Doc update   | yes


## Describe your change
Add an ObjectData class and a property in the Insights Conversion event

## What problem is this fixing?
Couldn't put ObjectData in a Conversion event before