### PR TITLE
fix: enable omitting order property in FacetValuesOrder

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetValuesOrder.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/rule/FacetValuesOrder.kt
@@ -1,17 +1,22 @@
 package com.algolia.search.model.rule
 
 import com.algolia.search.serialize.internal.Key
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 public data class FacetValuesOrder(
-    /**
-     * Pinned order of facet values.
-     */
-    @SerialName(Key.Order) public val order: List<String> = emptyList(),
     /**
      * How to display the remaining items.
      */
-    @SerialName(Key.SortRemainingBy) public val sortRemainingBy: SortRule? = null
+    @SerialName(Key.SortRemainingBy) public val sortRemainingBy: SortRule? = null,
+    /**
+     * Pinned order of facet values.
+     */
+    @SerialName(Key.Order)
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    public val order: List<String>? = null
 )

--- a/client/src/commonTest/kotlin/serialize/settings/TestFacetValuesOrder.kt
+++ b/client/src/commonTest/kotlin/serialize/settings/TestFacetValuesOrder.kt
@@ -1,0 +1,36 @@
+package serialize.settings
+
+import com.algolia.search.model.rule.FacetValuesOrder
+import com.algolia.search.model.rule.SortRule
+import com.algolia.search.serialize.internal.Key
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import serialize.TestSerializer
+import string
+
+internal class TestFacetValuesOrder : TestSerializer<FacetValuesOrder>(FacetValuesOrder.serializer()) {
+
+    override val items = listOf(
+        FacetValuesOrder(
+            sortRemainingBy = SortRule.Alpha
+        ) to buildJsonObject {
+            put(Key.SortRemainingBy, Key.Alpha)
+        },
+        FacetValuesOrder(
+            sortRemainingBy = SortRule.Count,
+            order = listOf(string)
+        ) to buildJsonObject {
+            put(Key.SortRemainingBy, Key.Count)
+            put(Key.Order, buildJsonArray { add(string) })
+        },
+        FacetValuesOrder(
+            sortRemainingBy = SortRule.Hidden,
+            order = emptyList()
+        ) to buildJsonObject {
+            put(Key.SortRemainingBy, Key.Hidden)
+            put(Key.Order, buildJsonArray {  })
+        }
+    )
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix [CR-6138]
| Need Doc update   | no


## Describe your change

`FacetValuesOrder` is now polymorphic so its `order` property can be optional

## What problem is this fixing?

The engine can send a `FacetValuesOrder` object without an `order` property, so we weren't able to deserialize it properly

[CR-6138]: https://algolia.atlassian.net/browse/CR-6138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ