### PR TITLE
fix(search): make some props optional when listing indices

### DIFF
--- a/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseListIndices.kt
+++ b/client/src/commonMain/kotlin/com/algolia/search/model/response/ResponseListIndices.kt
@@ -45,20 +45,29 @@ public data class ResponseListIndices(
         /**
          * Last build time in seconds.
          */
-        @SerialName(Key.LastBuildTimeS) val lastBuildTimeS: Int,
+        @SerialName(Key.LastBuildTimeS) val lastBuildTimeSOrNull: Int? = null,
         /**
          * Number of pending indexing operations.
          */
-        @SerialName(Key.NumberOfPendingTasks) val numberOfPendingTasks: Int,
+        @SerialName(Key.NumberOfPendingTasks) val numberOfPendingTasksOrNull: Int? = null,
         /**
          * A boolean which says whether the index has pending tasks.
          */
-        @SerialName(Key.PendingTask) val pendingTask: Boolean,
+        @SerialName(Key.PendingTask) val pendingTaskOrNull: Boolean? = null,
         @SerialName(Key.Replicas) val replicasOrNull: List<IndexName>? = null,
         @SerialName(Key.Primary) val primaryOrNull: IndexName? = null,
         @SerialName(Key.SourceABTest) val sourceABTestOrNull: IndexName? = null,
         @SerialName(Key.ABTest) val abTestOrNull: ResponseABTestShort? = null
     ) {
+
+        public val lastBuildTimeS: Int
+            get() = lastBuildTimeSOrNull!!
+
+        public val numberOfPendingTasks: Int
+            get() = numberOfPendingTasksOrNull!!
+
+        public val pendingTask: Boolean
+            get() = pendingTaskOrNull!!
 
         public val replicas: List<IndexName>
             get() = replicasOrNull!!

--- a/client/src/commonTest/kotlin/model/response/TestResponseListIndices.kt
+++ b/client/src/commonTest/kotlin/model/response/TestResponseListIndices.kt
@@ -1,0 +1,45 @@
+package model.response
+
+import com.algolia.search.model.ClientDate
+import com.algolia.search.model.IndexName
+import com.algolia.search.model.response.ResponseListIndices
+import com.algolia.search.serialize.internal.Key
+import shouldEqual
+import kotlin.test.Test
+import kotlinx.serialization.json.*
+
+internal class TestResponseListIndices {
+
+    @Test
+    fun dx() {
+        val json = buildJsonObject {
+            put(Key.Name, "indexName")
+            put(Key.CreatedAt, "2024-07-26T13:20:00Z")
+            put(Key.UpdatedAt, "2024-08-05T15:17:04Z")
+            put(Key.Entries, 0)
+            put(Key.DataSize, 0)
+            put(Key.FileSize, 0)
+            put(Key.NumberOfPendingTasks, 0)
+            put(Key.Replicas,
+                buildJsonArray { add("replicas") }
+            )
+            put(Key.Primary, "primary")
+            put(Key.SourceABTest, "sourceABTest")
+        }
+        val item = ResponseListIndices.Item(
+            indexName = IndexName("indexName"),
+            createdAt = ClientDate(1722000000000),
+            updatedAt = ClientDate(1722871024000),
+            entries = 0,
+            dataSize = 0,
+            fileSize = 0,
+            numberOfPendingTasksOrNull = 0,
+            replicasOrNull = listOf(IndexName("replicas")),
+            primaryOrNull = IndexName("primary"),
+            sourceABTestOrNull = IndexName("sourceABTest"),
+            abTestOrNull = null
+        )
+
+        Json.encodeToJsonElement(ResponseListIndices.Item.serializer(), item) shouldEqual json
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix [CR-6376] [DI-2696]
| Need Doc update   | no


## Describe your change

Make some props optional when deserializing list indices endpoint responses

## What problem is this fixing?

Some props were required while the API may not always provide them

[CR-6376]: https://algolia.atlassian.net/browse/CR-6376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DI-2696]: https://algolia.atlassian.net/browse/DI-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ